### PR TITLE
feat: reuse matt engineering skills

### DIFF
--- a/.codex/skills/ask-ai-workbench/SKILL.md
+++ b/.codex/skills/ask-ai-workbench/SKILL.md
@@ -25,6 +25,12 @@ asks for it.
 Return the recommendations and their short match reasons. Recommending no Skill
 is a normal result.
 
+If the repository has a project-local `ask-matt` Skill and the task is general
+engineering work rather than an AI Workbench Goal, Contract, Harness, daemon,
+or Evidence question, recommend `$ask-matt` first. Do not copy or reimplement
+its flow router. The user may invoke it to select an upstream Skill; this Skill
+remains advisory.
+
 This is advisory only. Do not invoke any recommended Skill, submit a Goal,
 write files, install anything, start a daemon, change permissions, or expand
 the task scope unless the user separately asks for that action.

--- a/.codex/skills/draft-aiwb-contract/SKILL.md
+++ b/.codex/skills/draft-aiwb-contract/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: draft-aiwb-contract
+description: Create an unapproved AI Workbench Contract draft from an already-approved local tickets.md breakdown. Use after to-tickets and before any unattended Goal is approved.
+---
+
+# Draft AI Workbench Contract
+
+Use this Skill only after the owner has approved a local `tickets.md` breakdown
+created by `$to-tickets`. It is a bridge between upstream planning and AI
+Workbench's execution boundary; it does not replace either.
+
+## Create the draft
+
+Require concrete repository, tickets, and output paths. Run:
+
+```bash
+aiwb goal draft --repo /path/to/repository \
+  --tickets /path/to/repository/tickets.md \
+  --output /path/to/repository/feature.contract.yaml
+```
+
+In this source checkout, when `aiwb` is not installed on `PATH`, use:
+
+```bash
+PYTHONPATH=tools/agent-orchestrator/src python3 -m aiwb goal draft \
+  --repo /path/to/repository \
+  --tickets /path/to/repository/tickets.md \
+  --output /path/to/repository/feature.contract.yaml
+```
+
+The command maps ticket titles to Todos, `Blocked by` edges to `depends_on`,
+and ticket acceptance criteria to test IDs. It accepts only the standard local
+`tickets.md` template; tracker fetching remains the issue tracker's and
+upstream Skill's responsibility.
+
+## Review boundary
+
+The result is deliberately not executable:
+
+- `approval.status` stays `draft`.
+- Every Todo has placeholder test commands and allowed paths.
+- Harness choice, permissions, provider, candidate publication, and final test
+  capabilities remain owner review decisions.
+
+Explain the generated draft and the required review. Do not change the approval
+status, fill placeholders, submit a Goal, start a daemon, or infer a Harness.
+Use `$run-approved-goal` only after the owner has completed and explicitly
+approved the Contract.

--- a/.codex/skills/setup-ai-workbench/SKILL.md
+++ b/.codex/skills/setup-ai-workbench/SKILL.md
@@ -69,24 +69,25 @@ directory. It never writes to user-global Agent configuration.
 Offer packs only after inspection and only by explicit user choice. `matt` is
 an installable, project-local pack pinned to a reviewed public release;
 `anthropic` is reference-only and must not be installed. Ask the user to choose
-specific Matt Skills rather than installing the collection wholesale. Show the
-source, revision, target Agent, selected Skill names, and resulting project
-paths before applying.
+either a reviewed Matt profile or specific Skills, rather than installing the
+collection wholesale. Show the source, revision, target Agent, selected profile
+or Skill names, and resulting project paths before applying.
 
-For example, after confirmation:
+For a reviewed, complete engineering flow after confirmation:
 
 ```bash
 aiwb setup --repo /path/to/repository --agent-target codex \
   --install-pack matt \
-  --pack-skill matt=ask-matt \
-  --pack-skill matt=setup-matt-pocock-skills \
+  --pack-profile matt=engineering \
   --apply
 ```
 
-The installer writes only project-local Agent Skill directories plus its
-project lock file. Do not pass global, bypass, or all-Skills options. After a
-Matt install, tell the user to invoke `$setup-matt-pocock-skills`; do not run
-that interactive configuration Skill automatically.
+The `engineering` profile is the reviewed dependency closure of upstream
+`ask-matt`, rather than the entire upstream collection. The installer writes
+only project-local Agent Skill directories plus its project lock file. Do not
+pass global, bypass, or all-Skills options. After a Matt install, tell the user
+to invoke `$setup-matt-pocock-skills`; do not run that interactive
+configuration Skill automatically.
 
 ## Finish
 

--- a/decisions/0003-upstream-engineering-skills-and-contract-drafts.md
+++ b/decisions/0003-upstream-engineering-skills-and-contract-drafts.md
@@ -1,0 +1,43 @@
+# 0003 - Reuse Upstream Engineering Skills and Bridge Only at the Contract Boundary
+
+## Status
+
+Accepted
+
+## Context
+
+AI Workbench provides durable, unattended execution: approved Contracts,
+isolated Todo worktrees, test gates, Harnesses, Evidence, and recovery. It
+should not independently recreate interactive engineering disciplines already
+maintained upstream, such as idea grilling, specification writing, ticket
+splitting, TDD, and architecture review.
+
+`mattpocock/skills` supplies those small, composable Skills. Its engineering
+router is useful only when its referenced Skills are present, and its public
+release should be consumed at a reviewed immutable revision rather than a
+moving installer default or tag.
+
+## Decision
+
+Keep Matt Skills optional and project-local. Offer one reviewed `matt`
+`engineering` profile containing the dependency closure of `ask-matt`'s
+engineering routes, pinned to the reviewed source commit. `ask-ai-workbench`
+recommends an installed `ask-matt` router for general engineering work instead
+of copying its routing logic.
+
+AI Workbench owns only a thin local `tickets.md` to Contract-draft bridge. It
+preserves ticket slices, acceptance criteria, and blocking edges, but generates
+an intentionally unapproved Contract with test placeholders. The owner must
+still choose approved commands, Harnesses, permissions, and approval before an
+unattended Run can begin.
+
+Do not invoke upstream `implement` inside the durable Runner: it owns its own
+interactive commit and review loop, while the Runner owns worktrees,
+checkpoints, integration, and Evidence.
+
+## Consequences
+
+The planning and interactive implementation experience can evolve with the
+upstream project. AI Workbench remains narrow at its unique execution boundary,
+and a malformed or incomplete ticket breakdown cannot silently become an
+authorized overnight Goal.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -8,3 +8,4 @@ Use this directory for durable repository rules. Personal tasks belong in `todo/
 
 - [0001 - Repository Scope and Structure](0001-repository-scope-and-structure.md)
 - [0002 - Add a Generic Unattended Agent Orchestrator](0002-unattended-agent-orchestrator.md)
+- [0003 - Reuse Upstream Engineering Skills and Contract Drafts](0003-upstream-engineering-skills-and-contract-drafts.md)

--- a/skills/agent-orchestrator.md
+++ b/skills/agent-orchestrator.md
@@ -11,9 +11,10 @@
 The bundled interaction Skills are:
 
 - [`run-approved-goal`](../tools/agent-orchestrator/skills/run-approved-goal/), which uses the local `ai-workbench` MCP server and does not own the Run lifecycle;
+- [`draft-aiwb-contract`](../tools/agent-orchestrator/skills/draft-aiwb-contract/), which turns an approved local `tickets.md` breakdown into a deliberately unapproved Contract draft;
 - [`setup-ai-workbench`](../tools/agent-orchestrator/skills/setup-ai-workbench/), which inspects first and requires explicit confirmation before project-local setup;
 - [`ask-ai-workbench`](../tools/agent-orchestrator/skills/ask-ai-workbench/), which only recommends up to two optional Skills for a task.
 
-The two onboarding Skills are mirrored under [`.codex/skills`](../.codex/skills/)
+The three interactive Skills are mirrored under [`.codex/skills`](../.codex/skills/)
 so a Codex Agent operating this repository can invoke them without a global
 installation.

--- a/skills/matt-pocock-skills.md
+++ b/skills/matt-pocock-skills.md
@@ -9,6 +9,8 @@
 ## Notes
 
 Good reference for small, composable skills that keep the user in control of the process.
-AI Workbench can install explicitly selected Skills project-locally through
-`aiwb setup --install-pack matt`; it pins the reviewed `v1.1.0` release and
-never installs the full collection or runs its interactive setup automatically.
+AI Workbench can install an explicitly selected project-local profile through
+`aiwb setup --install-pack matt --pack-profile matt=engineering`; it pins the
+reviewed `v1.1.0` commit and installs the dependency closure of the upstream
+engineering router, not the full collection. It never runs the interactive
+upstream setup automatically.

--- a/tools/agent-orchestrator/README.md
+++ b/tools/agent-orchestrator/README.md
@@ -317,7 +317,7 @@ codex mcp list
 
 Registration is intentionally a user action; the repository never edits global Codex configuration. The MCP server needs no network access or OpenAI API key. It connects only to the local `0600` daemon socket. Start or install the daemon separately before using the tools.
 
-The bundled interaction Skills live in [`skills/`](skills/): `run-approved-goal`, `setup-ai-workbench`, and `ask-ai-workbench`. To make one globally discoverable, the user may copy or link its directory into `$CODEX_HOME/skills/<name>` (or `~/.codex/skills/<name>` when `CODEX_HOME` is unset). The repository never performs that global change itself. `run-approved-goal` submits an approved Contract and observes its durable Run; `$setup-ai-workbench` inspects first and requires explicit confirmation before project-local setup; `$ask-ai-workbench` is advisory and can return no recommendation.
+The bundled interaction Skills live in [`skills/`](skills/): `run-approved-goal`, `draft-aiwb-contract`, `setup-ai-workbench`, and `ask-ai-workbench`. To make one globally discoverable, the user may copy or link its directory into `$CODEX_HOME/skills/<name>` (or `~/.codex/skills/<name>` when `CODEX_HOME` is unset). The repository never performs that global change itself. `run-approved-goal` submits an approved Contract and observes its durable Run; `draft-aiwb-contract` converts approved local `tickets.md` content into a non-runnable Contract draft; `$setup-ai-workbench` inspects first and requires explicit confirmation before project-local setup; `$ask-ai-workbench` is advisory and can return no recommendation.
 
 For direct CLI use, inspect first and add `--apply` only after reviewing the exact planned changes:
 
@@ -337,18 +337,35 @@ revision, then explicitly name each Skill and target:
 ```bash
 aiwb setup --repo /path/to/project --agent-target codex \
   --install-pack matt \
-  --pack-skill matt=ask-matt \
-  --pack-skill matt=setup-matt-pocock-skills \
+  --pack-profile matt=engineering \
   --apply
 ```
 
-This invokes the fixed `skills@1.5.9` installer against
-`mattpocock/skills` release `v1.1.0` (resolved during review to
-`d574778f94cf620fcc8ce741584093bc650a61d3`), with `--copy` and no global or
+The `engineering` profile is the reviewed dependency closure of upstream
+`ask-matt`'s engineering flow, not the whole upstream collection. This invokes
+the fixed `skills@1.5.9` installer against the reviewed commit
+`d574778f94cf620fcc8ce741584093bc650a61d3`, with `--copy` and no global or
 all-Skills option. It writes project-local Skill directories and the
 installer's lock file. Then invoke `$setup-matt-pocock-skills` yourself to
 choose its issue-tracker, label, and document settings. Anthropic is listed as
 reference-only until separately reviewed.
+
+## From Matt tickets to an AI Workbench Contract
+
+Use `$to-tickets` to agree and publish local `tickets.md` first. Then create a
+draft that preserves the vertical slices, blocking edges, and acceptance
+criteria without granting any execution authority:
+
+```bash
+aiwb goal draft --repo /path/to/project \
+  --tickets /path/to/project/tickets.md \
+  --output /path/to/project/greeting.contract.yaml
+```
+
+The generated file has `approval.status: draft` and placeholder test commands.
+Review it against the project's workflow policy, replace every placeholder,
+and explicitly approve it before using `run-approved-goal`. The command does
+not fetch a tracker, configure a Harness, start a daemon, or submit a Goal.
 
 For macOS background operation, inspect the plist without loading it:
 

--- a/tools/agent-orchestrator/skills/ask-ai-workbench/SKILL.md
+++ b/tools/agent-orchestrator/skills/ask-ai-workbench/SKILL.md
@@ -25,6 +25,12 @@ asks for it.
 Return the recommendations and their short match reasons. Recommending no Skill
 is a normal result.
 
+If the repository has a project-local `ask-matt` Skill and the task is general
+engineering work rather than an AI Workbench Goal, Contract, Harness, daemon,
+or Evidence question, recommend `$ask-matt` first. Do not copy or reimplement
+its flow router. The user may invoke it to select an upstream Skill; this Skill
+remains advisory.
+
 This is advisory only. Do not invoke any recommended Skill, submit a Goal,
 write files, install anything, start a daemon, change permissions, or expand
 the task scope unless the user separately asks for that action.

--- a/tools/agent-orchestrator/skills/draft-aiwb-contract/SKILL.md
+++ b/tools/agent-orchestrator/skills/draft-aiwb-contract/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: draft-aiwb-contract
+description: Create an unapproved AI Workbench Contract draft from an already-approved local tickets.md breakdown. Use after to-tickets and before any unattended Goal is approved.
+---
+
+# Draft AI Workbench Contract
+
+Use this Skill only after the owner has approved a local `tickets.md` breakdown
+created by `$to-tickets`. It is a bridge between upstream planning and AI
+Workbench's execution boundary; it does not replace either.
+
+## Create the draft
+
+Require concrete repository, tickets, and output paths. Run:
+
+```bash
+aiwb goal draft --repo /path/to/repository \
+  --tickets /path/to/repository/tickets.md \
+  --output /path/to/repository/feature.contract.yaml
+```
+
+In this source checkout, when `aiwb` is not installed on `PATH`, use:
+
+```bash
+PYTHONPATH=tools/agent-orchestrator/src python3 -m aiwb goal draft \
+  --repo /path/to/repository \
+  --tickets /path/to/repository/tickets.md \
+  --output /path/to/repository/feature.contract.yaml
+```
+
+The command maps ticket titles to Todos, `Blocked by` edges to `depends_on`,
+and ticket acceptance criteria to test IDs. It accepts only the standard local
+`tickets.md` template; tracker fetching remains the issue tracker's and
+upstream Skill's responsibility.
+
+## Review boundary
+
+The result is deliberately not executable:
+
+- `approval.status` stays `draft`.
+- Every Todo has placeholder test commands and allowed paths.
+- Harness choice, permissions, provider, candidate publication, and final test
+  capabilities remain owner review decisions.
+
+Explain the generated draft and the required review. Do not change the approval
+status, fill placeholders, submit a Goal, start a daemon, or infer a Harness.
+Use `$run-approved-goal` only after the owner has completed and explicitly
+approved the Contract.

--- a/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
+++ b/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
@@ -69,24 +69,25 @@ directory. It never writes to user-global Agent configuration.
 Offer packs only after inspection and only by explicit user choice. `matt` is
 an installable, project-local pack pinned to a reviewed public release;
 `anthropic` is reference-only and must not be installed. Ask the user to choose
-specific Matt Skills rather than installing the collection wholesale. Show the
-source, revision, target Agent, selected Skill names, and resulting project
-paths before applying.
+either a reviewed Matt profile or specific Skills, rather than installing the
+collection wholesale. Show the source, revision, target Agent, selected profile
+or Skill names, and resulting project paths before applying.
 
-For example, after confirmation:
+For a reviewed, complete engineering flow after confirmation:
 
 ```bash
 aiwb setup --repo /path/to/repository --agent-target codex \
   --install-pack matt \
-  --pack-skill matt=ask-matt \
-  --pack-skill matt=setup-matt-pocock-skills \
+  --pack-profile matt=engineering \
   --apply
 ```
 
-The installer writes only project-local Agent Skill directories plus its
-project lock file. Do not pass global, bypass, or all-Skills options. After a
-Matt install, tell the user to invoke `$setup-matt-pocock-skills`; do not run
-that interactive configuration Skill automatically.
+The `engineering` profile is the reviewed dependency closure of upstream
+`ask-matt`, rather than the entire upstream collection. The installer writes
+only project-local Agent Skill directories plus its project lock file. Do not
+pass global, bypass, or all-Skills options. After a Matt install, tell the user
+to invoke `$setup-matt-pocock-skills`; do not run that interactive
+configuration Skill automatically.
 
 ## Finish
 

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -19,6 +19,7 @@ from .runner import GoalRunner
 from .setup import WorkbenchSetup
 from .skills import SkillCatalog
 from .supervisor import LaunchdError, LaunchdService
+from .tickets import TicketContractDraftBuilder
 
 
 def main(arguments: Optional[Sequence[str]] = None) -> int:
@@ -74,6 +75,7 @@ def _build_parser() -> argparse.ArgumentParser:
     setup.add_argument("--install-skill", action="append", default=[])
     setup.add_argument("--install-pack", action="append", default=[])
     setup.add_argument("--pack-skill", action="append", default=[])
+    setup.add_argument("--pack-profile", action="append", default=[])
     setup.add_argument("--apply", action="store_true")
 
     skills = commands.add_parser("skills")
@@ -118,6 +120,12 @@ def _build_parser() -> argparse.ArgumentParser:
     report = goal_commands.add_parser("report")
     report.add_argument("run_id")
     _add_control_options(report)
+
+    draft = goal_commands.add_parser("draft")
+    draft.add_argument("--repo", required=True, type=Path)
+    draft.add_argument("--tickets", required=True, type=Path)
+    draft.add_argument("--output", required=True, type=Path)
+    draft.add_argument("--force", action="store_true")
 
     daemon = commands.add_parser("daemon")
     daemon_commands = daemon.add_subparsers(dest="daemon_command", required=True)
@@ -181,6 +189,7 @@ def _run_setup(options: argparse.Namespace) -> int:
     targets = tuple(options.agent_target)
     role_skills = _role_skills(options.role_skill)
     pack_skills = _pack_skills(options.install_pack, options.pack_skill)
+    pack_profiles = _pack_profiles(options.install_pack, options.pack_profile)
     if options.apply:
         result = setup.apply(
             repository=options.repo,
@@ -189,6 +198,7 @@ def _run_setup(options: argparse.Namespace) -> int:
             role_skills=role_skills,
             install_skills=tuple(options.install_skill),
             pack_skills=pack_skills,
+            pack_profiles=pack_profiles,
         )
         _print_json(
             {
@@ -210,7 +220,7 @@ def _run_setup(options: argparse.Namespace) -> int:
                 "agent_targets": result.agent_targets,
                 "skills": [skill.__dict__ for skill in result.catalog.skills],
                 "warnings": result.catalog.warnings,
-                "packs": [pack.__dict__ for pack in result.packs],
+                "packs": [_pack_to_dict(pack) for pack in result.packs],
             }
         )
     return 0
@@ -238,6 +248,15 @@ def _run_doctor(options: argparse.Namespace) -> int:
 
 
 def _run_goal(options: argparse.Namespace) -> int:
+    if options.goal_command == "draft":
+        result = TicketContractDraftBuilder().create(
+            tickets_path=options.tickets,
+            repository=options.repo,
+            output_path=options.output,
+            force=options.force,
+        )
+        _print_json(result.__dict__)
+        return 0
     if options.goal_command == "run":
         report = GoalRunner(
             state_dir=options.state_dir,
@@ -338,6 +357,33 @@ def _pack_skills(
             raise ValueError("pack skills require a matching --install-pack")
         selected[pack].append(skill)
     return {pack: tuple(skills) for pack, skills in selected.items()}
+
+
+def _pack_profiles(
+    packs: Sequence[str],
+    values: Sequence[str],
+) -> dict[str, Tuple[str, ...]]:
+    selected = {name: [] for name in packs}
+    for value in values:
+        pack, separator, profile = value.partition("=")
+        if not separator or not pack or not profile:
+            raise ValueError("pack profiles must use PACK=PROFILE")
+        if pack not in selected:
+            raise ValueError("pack profiles require a matching --install-pack")
+        selected[pack].append(profile)
+    return {pack: tuple(profiles) for pack, profiles in selected.items() if profiles}
+
+
+def _pack_to_dict(pack) -> dict[str, object]:
+    return {
+        "name": pack.name,
+        "description": pack.description,
+        "source": pack.source,
+        "revision": pack.revision,
+        "installable": pack.installable,
+        "setup_action": pack.setup_action,
+        "profiles": [profile.__dict__ for profile in pack.profiles],
+    }
 
 
 def _agent_router(options: argparse.Namespace) -> AgentRouter:

--- a/tools/agent-orchestrator/src/aiwb/setup.py
+++ b/tools/agent-orchestrator/src/aiwb/setup.py
@@ -79,15 +79,21 @@ class WorkbenchSetup:
         role_skills: Optional[Mapping[str, Sequence[str]]] = None,
         install_skills: Tuple[str, ...] = (),
         pack_skills: Optional[Mapping[str, Sequence[str]]] = None,
+        pack_profiles: Optional[Mapping[str, Sequence[str]]] = None,
     ) -> SetupApplyResult:
         if not confirmed:
             raise ValueError("setup requires explicit confirmation before writing")
         inspection = self.inspect(repository, agent_targets)
         repository = Path(repository).expanduser().resolve()
         selected_packs = pack_skills or {}
-        if (install_skills or selected_packs) and not agent_targets:
+        selected_profiles = pack_profiles or {}
+        if (install_skills or selected_packs or selected_profiles) and not agent_targets:
             raise ValueError("installing a Skill requires an explicit agent target")
-        pack_plans = self._pack_catalog.plans(selected_packs, agent_targets)
+        pack_plans = self._pack_catalog.plans(
+            selected_packs,
+            agent_targets,
+            profiles=selected_profiles,
+        )
         workflow = Path(inspection.workflow_path)
         created = not workflow.exists()
         if created:

--- a/tools/agent-orchestrator/src/aiwb/skills.py
+++ b/tools/agent-orchestrator/src/aiwb/skills.py
@@ -47,6 +47,16 @@ class SkillPackDescriptor:
     revision: str
     installable: bool
     setup_action: str = ""
+    profiles: Tuple["SkillPackProfileDescriptor", ...] = ()
+
+
+@dataclass(frozen=True)
+class SkillPackProfileDescriptor:
+    """A reviewed, named selection from an optional upstream Skill pack."""
+
+    name: str
+    description: str
+    skills: Tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -65,6 +75,12 @@ class SkillCatalog:
             description="Submit and observe an approved unattended Goal with Evidence.",
             source="bundled",
             path="skills/run-approved-goal/SKILL.md",
+        ),
+        SkillDescriptor(
+            name="draft-aiwb-contract",
+            description="Create an unapproved Contract draft from approved local tickets.",
+            source="bundled",
+            path="skills/draft-aiwb-contract/SKILL.md",
         ),
         SkillDescriptor(
             name="setup-ai-workbench",
@@ -94,24 +110,42 @@ class SkillCatalog:
         if limit < 1:
             raise ValueError("limit must be positive")
 
+        snapshot = self.inspect(repository)
         task_terms = _terms(task)
         ranked = []
-        for skill in self.inspect(repository).skills:
+        for skill in snapshot.skills:
             matches = sorted(task_terms & _terms(f"{skill.name} {skill.description}"))
             if len(matches) >= 2:
                 ranked.append((len(matches), skill, matches))
         ranked.sort(key=lambda item: (-item[0], item[1].name))
-        return SkillRecommendationResult(
-            recommendations=tuple(
+        router = next(
+            (skill for skill in snapshot.skills if skill.name == "ask-matt"),
+            None,
+        )
+        recommendations = []
+        if router is not None and not _is_aiwb_task(task_terms):
+            recommendations.append(
                 SkillRecommendation(
-                    name=skill.name,
-                    description=skill.description,
-                    source=skill.source,
-                    path=skill.path,
-                    reason="matched: " + ", ".join(matches),
+                    name=router.name,
+                    description=router.description,
+                    source=router.source,
+                    path=router.path,
+                    reason="installed upstream engineering router",
                 )
-                for _, skill, matches in ranked[:limit]
             )
+        recommendations.extend(
+            SkillRecommendation(
+                name=skill.name,
+                description=skill.description,
+                source=skill.source,
+                path=skill.path,
+                reason="matched: " + ", ".join(matches),
+            )
+            for _, skill, matches in ranked
+            if skill.name != "ask-matt"
+        )
+        return SkillRecommendationResult(
+            recommendations=tuple(recommendations[:limit])
         )
 
     def inspect(self, repository: Path) -> SkillCatalogSnapshot:
@@ -191,6 +225,23 @@ def _terms(value: str) -> set[str]:
     }
 
 
+def _is_aiwb_task(task_terms: set[str]) -> bool:
+    return bool(
+        task_terms
+        & {
+            "aiwb",
+            "approved",
+            "candidate",
+            "contract",
+            "daemon",
+            "evidence",
+            "goal",
+            "harness",
+            "unattended",
+        }
+    )
+
+
 def _metadata(content: str) -> Optional[dict[str, object]]:
     if not content.startswith("---\n"):
         return None
@@ -210,10 +261,42 @@ class SkillPackCatalog:
         SkillPackDescriptor(
             name="matt",
             description="Selected small engineering Skills from mattpocock/skills.",
-            source="https://github.com/mattpocock/skills/tree/v1.1.0",
+            source="https://github.com/mattpocock/skills/tree/d574778f94cf620fcc8ce741584093bc650a61d3",
             revision="v1.1.0 (resolved d574778f94cf620fcc8ce741584093bc650a61d3)",
             installable=True,
             setup_action="$setup-matt-pocock-skills",
+            profiles=(
+                SkillPackProfileDescriptor(
+                    name="engineering",
+                    description=(
+                        "Dependency-complete ask-matt engineering flow; excludes "
+                        "deprecated, in-progress, personal, and unrelated upstream Skills."
+                    ),
+                    skills=(
+                        "setup-matt-pocock-skills",
+                        "ask-matt",
+                        "grill-with-docs",
+                        "grill-me",
+                        "grilling",
+                        "handoff",
+                        "prototype",
+                        "to-spec",
+                        "to-tickets",
+                        "implement",
+                        "tdd",
+                        "code-review",
+                        "codebase-design",
+                        "domain-modeling",
+                        "improve-codebase-architecture",
+                        "triage",
+                        "diagnosing-bugs",
+                        "wayfinder",
+                        "research",
+                        "teach",
+                        "writing-great-skills",
+                    ),
+                ),
+            ),
         ),
         SkillPackDescriptor(
             name="anthropic",
@@ -231,16 +314,28 @@ class SkillPackCatalog:
         self,
         selections: Mapping[str, Sequence[str]],
         agent_targets: Tuple[str, ...],
+        profiles: Optional[Mapping[str, Sequence[str]]] = None,
     ) -> Tuple[SkillPackInstallPlan, ...]:
         plans = []
         descriptors = {pack.name: pack for pack in self._PACKS}
-        for name, requested_skills in selections.items():
+        profile_selections = profiles or {}
+        pack_names = tuple(dict.fromkeys((*selections.keys(), *profile_selections.keys())))
+        for name in pack_names:
             pack = descriptors.get(name)
             if pack is None:
                 raise ValueError(f"unknown Skill pack: {name}")
             if not pack.installable:
                 raise ValueError(f"Skill pack is reference-only: {name}")
-            skills = tuple(dict.fromkeys(requested_skills))
+            profiles_by_name = {profile.name: profile for profile in pack.profiles}
+            profile_skills = []
+            for profile_name in profile_selections.get(name, ()):
+                profile = profiles_by_name.get(profile_name)
+                if profile is None:
+                    raise ValueError(f"unknown Skill pack profile: {name}={profile_name}")
+                profile_skills.extend(profile.skills)
+            skills = tuple(
+                dict.fromkeys((*profile_skills, *selections.get(name, ())))
+            )
             if not skills:
                 raise ValueError(f"Skill pack requires selected Skills: {name}")
             if any(not re.fullmatch(r"[a-z0-9-]+", skill) for skill in skills):

--- a/tools/agent-orchestrator/src/aiwb/tickets.py
+++ b/tools/agent-orchestrator/src/aiwb/tickets.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+
+import yaml
+
+
+_TITLE = re.compile(r"^# Tickets:\s*(?P<title>.+?)\s*$")
+_TICKET = re.compile(r"^##\s+(?P<title>.+?)\s*$")
+_WHAT = re.compile(r"^\*\*What to build:\*\*\s*(?P<value>.+?)\s*$")
+_BLOCKED_BY = re.compile(r"^\*\*Blocked by:\*\*\s*(?P<value>.+?)\s*$")
+_ACCEPTANCE = re.compile(r"^- \[ \]\s+(?P<value>.+?)\s*$")
+
+
+class TicketDraftError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class TicketContractDraftResult:
+    output: str
+    ticket_count: int
+    acceptance_count: int
+    status: str = "draft"
+
+
+@dataclass(frozen=True)
+class _Ticket:
+    title: str
+    requirement: str
+    blocked_by: Tuple[str, ...]
+    acceptance: Tuple[str, ...]
+
+
+class TicketContractDraftBuilder:
+    """Convert a local `to-tickets` document into a deliberately unapproved Contract."""
+
+    def create(
+        self,
+        tickets_path: Path,
+        repository: Path,
+        output_path: Path,
+        force: bool = False,
+    ) -> TicketContractDraftResult:
+        tickets_path = Path(tickets_path).expanduser().resolve()
+        repository = Path(repository).expanduser().resolve()
+        output_path = Path(output_path).expanduser().resolve()
+        if not tickets_path.is_file():
+            raise TicketDraftError(f"tickets file is not readable: {tickets_path}")
+        if not repository.is_dir():
+            raise TicketDraftError(f"repository is not a directory: {repository}")
+        if output_path.exists() and not force:
+            raise TicketDraftError(f"draft output already exists: {output_path}")
+
+        title, requirement, tickets = _parse_tickets(tickets_path)
+        document = _draft_document(title, requirement, tickets, repository, tickets_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            yaml.safe_dump(document, sort_keys=False),
+            encoding="utf-8",
+        )
+        return TicketContractDraftResult(
+            output=str(output_path),
+            ticket_count=len(tickets),
+            acceptance_count=sum(len(ticket.acceptance) for ticket in tickets),
+        )
+
+
+def _parse_tickets(path: Path) -> Tuple[str, str, Tuple[_Ticket, ...]]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    title = ""
+    requirement = ""
+    raw_tickets: List[dict[str, object]] = []
+    current: dict[str, object] | None = None
+
+    for line in lines:
+        if not title:
+            match = _TITLE.match(line)
+            if match is not None:
+                title = match.group("title")
+            continue
+        match = _TICKET.match(line)
+        if match is not None:
+            current = {
+                "title": match.group("title"),
+                "requirement": "",
+                "blocked_by": [],
+                "acceptance": [],
+            }
+            raw_tickets.append(current)
+            continue
+        if current is None:
+            if line.strip() and not requirement:
+                requirement = line.strip()
+            continue
+        match = _WHAT.match(line)
+        if match is not None:
+            current["requirement"] = match.group("value")
+            continue
+        match = _BLOCKED_BY.match(line)
+        if match is not None:
+            current["blocked_by"] = _blockers(match.group("value"))
+            continue
+        match = _ACCEPTANCE.match(line)
+        if match is not None:
+            current["acceptance"].append(match.group("value"))
+
+    if not title:
+        raise TicketDraftError("tickets file must start with '# Tickets: <title>'")
+    if not raw_tickets:
+        raise TicketDraftError("tickets file must contain at least one '## <ticket>' section")
+    tickets = tuple(
+        _Ticket(
+            title=str(ticket["title"]),
+            requirement=str(ticket["requirement"]),
+            blocked_by=tuple(ticket["blocked_by"]),
+            acceptance=tuple(ticket["acceptance"]),
+        )
+        for ticket in raw_tickets
+    )
+    titles = {ticket.title for ticket in tickets}
+    if len(titles) != len(tickets):
+        raise TicketDraftError("ticket titles must be unique")
+    for ticket in tickets:
+        if not ticket.requirement:
+            raise TicketDraftError(f"ticket is missing 'What to build': {ticket.title}")
+        if not ticket.acceptance:
+            raise TicketDraftError(f"ticket is missing acceptance criteria: {ticket.title}")
+        unknown = set(ticket.blocked_by) - titles
+        if unknown:
+            raise TicketDraftError(
+                f"ticket has unknown blockers: {ticket.title}: {', '.join(sorted(unknown))}"
+            )
+    return title, requirement or f"Implement the approved tickets for {title}.", tickets
+
+
+def _blockers(value: str) -> List[str]:
+    normalized = value.strip()
+    if normalized.lower().startswith("none"):
+        return []
+    return [item.strip() for item in normalized.split(",") if item.strip()]
+
+
+def _draft_document(
+    title: str,
+    requirement: str,
+    tickets: Tuple[_Ticket, ...],
+    repository: Path,
+    tickets_path: Path,
+) -> dict[str, object]:
+    todo_ids = {ticket.title: f"T-{index}" for index, ticket in enumerate(tickets, start=1)}
+    acceptance = []
+    todos = []
+    for todo_index, ticket in enumerate(tickets, start=1):
+        test_ids = []
+        for acceptance_index, statement in enumerate(ticket.acceptance, start=1):
+            test_id = f"AC-{todo_index}-{acceptance_index}"
+            acceptance.append({"id": test_id, "statement": statement})
+            test_ids.append(test_id)
+        todos.append(
+            {
+                "id": todo_ids[ticket.title],
+                "title": ticket.title,
+                "depends_on": [todo_ids[blocker] for blocker in ticket.blocked_by],
+                "test_ids": test_ids,
+                "test": {
+                    "command": ["REPLACE_WITH_APPROVED_TEST_COMMAND"],
+                    "allowed_paths": ["REPLACE_WITH_APPROVED_TEST_PATH"],
+                    "timeout_seconds": 600,
+                },
+            }
+        )
+    return {
+        "schema_version": 1,
+        "draft": {
+            "source_tickets": str(tickets_path),
+            "review_required": [
+                "Replace each placeholder test command and allowed test path with project-approved capabilities.",
+                "Review the agent provider, harness, permissions, and candidate publication policy.",
+                "Set approval status, approver, and timestamp only after the Contract is complete.",
+            ],
+        },
+        "goal": {
+            "id": _goal_id(title),
+            "title": title,
+            "requirement": requirement,
+            "acceptance": acceptance,
+        },
+        "approval": {
+            "status": "draft",
+            "approved_by": "",
+            "approved_at": "",
+        },
+        "agent": {"provider": "codex"},
+        "project": {"repo": str(repository), "base_ref": "main"},
+        "todos": todos,
+    }
+
+
+def _goal_id(title: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return f"tickets-{slug or 'draft'}"

--- a/tools/agent-orchestrator/tests/test_skill_catalog.py
+++ b/tools/agent-orchestrator/tests/test_skill_catalog.py
@@ -76,3 +76,33 @@ def test_catalog_prefers_a_project_copy_of_a_bundled_skill() -> None:
             ("project", ".codex/skills/ask-ai-workbench/SKILL.md"),
         ]
         assert [item.name for item in result.recommendations] == ["ask-ai-workbench"]
+
+
+def test_catalog_recommends_installed_ask_matt_before_recreating_its_router() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "project"
+        router = repository / ".codex" / "skills" / "ask-matt" / "SKILL.md"
+        router.parent.mkdir(parents=True)
+        router.write_text(
+            "---\n"
+            "name: ask-matt\n"
+            "description: Ask which skill or flow fits your situation.\n"
+            "---\n",
+            encoding="utf-8",
+        )
+
+        result = SkillCatalog().recommend(
+            repository,
+            "design and implement a multi-session engineering feature",
+        )
+
+        assert [item.name for item in result.recommendations] == ["ask-matt"]
+        assert result.recommendations[0].reason == "installed upstream engineering router"
+
+
+def test_project_local_skill_mirrors_match_the_bundled_sources() -> None:
+    repository = TOOL_ROOT.parents[1]
+    for name in ("ask-ai-workbench", "setup-ai-workbench", "draft-aiwb-contract"):
+        bundled = TOOL_ROOT / "skills" / name / "SKILL.md"
+        mirrored = repository / ".codex" / "skills" / name / "SKILL.md"
+        assert mirrored.read_text(encoding="utf-8") == bundled.read_text(encoding="utf-8")

--- a/tools/agent-orchestrator/tests/test_skill_cli.py
+++ b/tools/agent-orchestrator/tests/test_skill_cli.py
@@ -7,6 +7,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import yaml
+
 
 TOOL_ROOT = Path(__file__).resolve().parents[1]
 
@@ -126,4 +128,62 @@ def test_setup_cli_lists_the_optional_matt_pack_without_installing_it() -> None:
         assert matt["revision"] == (
             "v1.1.0 (resolved d574778f94cf620fcc8ce741584093bc650a61d3)"
         )
+        assert matt["profiles"][0]["name"] == "engineering"
         assert not (repository / ".agents").exists()
+
+
+def test_goal_draft_converts_approved_local_tickets_to_an_unapproved_contract() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "project"
+        repository.mkdir()
+        tickets = repository / "tickets.md"
+        tickets.write_text(
+            "# Tickets: Greeting flow\n\n"
+            "Add greeting and farewell behavior.\n\n"
+            "## Add greeting\n\n"
+            "**What to build:** A user can receive a greeting.\n\n"
+            "**Blocked by:** None — can start immediately.\n\n"
+            "- [ ] Greeting includes the supplied name.\n\n"
+            "## Add farewell\n\n"
+            "**What to build:** A user can receive a farewell.\n\n"
+            "**Blocked by:** Add greeting\n\n"
+            "- [ ] Farewell includes the supplied name.\n",
+            encoding="utf-8",
+        )
+        output = repository / "greeting.contract.yaml"
+        environment = os.environ.copy()
+        environment["PYTHONPATH"] = str(TOOL_ROOT / "src")
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "aiwb",
+                "goal",
+                "draft",
+                "--repo",
+                str(repository),
+                "--tickets",
+                str(tickets),
+                "--output",
+                str(output),
+            ],
+            cwd=str(TOOL_ROOT),
+            env=environment,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        document = yaml.safe_load(output.read_text(encoding="utf-8"))
+        assert json.loads(completed.stdout)["status"] == "draft"
+        assert document["approval"]["status"] == "draft"
+        assert document["todos"][0]["depends_on"] == []
+        assert document["todos"][1]["depends_on"] == ["T-1"]
+        assert document["todos"][0]["test_ids"] == ["AC-1-1"]
+        assert document["todos"][1]["test_ids"] == ["AC-2-1"]
+        assert document["todos"][0]["test"]["command"] == [
+            "REPLACE_WITH_APPROVED_TEST_COMMAND"
+        ]

--- a/tools/agent-orchestrator/tests/test_workbench_setup.py
+++ b/tools/agent-orchestrator/tests/test_workbench_setup.py
@@ -143,7 +143,7 @@ def test_setup_installs_selected_matt_skills_with_a_project_target() -> None:
                     "--yes",
                     "skills@1.5.9",
                     "add",
-                    "https://github.com/mattpocock/skills/tree/v1.1.0",
+                    "https://github.com/mattpocock/skills/tree/d574778f94cf620fcc8ce741584093bc650a61d3",
                     "--copy",
                     "--yes",
                     "--agent",
@@ -156,6 +156,40 @@ def test_setup_installs_selected_matt_skills_with_a_project_target() -> None:
                 repository.resolve(),
             )
         ]
+
+
+def test_setup_installs_the_reviewed_matt_engineering_profile() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "project"
+        repository.mkdir()
+        calls = []
+
+        result = WorkbenchSetup(command_runner=lambda command, cwd: calls.append((command, cwd))).apply(
+            repository,
+            confirmed=True,
+            agent_targets=("codex",),
+            pack_profiles={"matt": ("engineering",)},
+        )
+
+        command, cwd = calls[0]
+        selected = tuple(
+            command[index + 1]
+            for index, item in enumerate(command)
+            if item == "--skill"
+        )
+        assert result.installed_packs == ("matt",)
+        assert cwd == repository.resolve()
+        assert command[4] == "https://github.com/mattpocock/skills/tree/d574778f94cf620fcc8ce741584093bc650a61d3"
+        assert selected[:4] == (
+            "setup-matt-pocock-skills",
+            "ask-matt",
+            "grill-with-docs",
+            "grill-me",
+        )
+        assert "to-spec" in selected
+        assert "to-tickets" in selected
+        assert "tdd" in selected
+        assert "improve-codebase-architecture" in selected
 
 
 def test_setup_keeps_reference_only_packs_uninstallable() -> None:


### PR DESCRIPTION
## What changed

- Add a reviewed, commit-pinned `matt=engineering` setup profile and route general engineering questions to an installed `ask-matt`.
- Add `aiwb goal draft` plus `draft-aiwb-contract` to convert local `tickets.md` into an intentionally unapproved Contract draft.
- Document the boundary and add ADR 0003; keep mirrored Codex skills synchronized.

## Why

Reuse upstream planning and engineering skills while keeping AI Workbench responsible only for the approved, durable execution boundary.

## Validation

- `python3 -m pytest -q` — 72 passed
- `python3 -m pytest tests/test_skill_catalog.py tests/test_workbench_setup.py tests/test_skill_cli.py -q` — 16 passed
- `git diff --check`