### PR TITLE
feat: support AIWB handoff and policy preflight

### DIFF
--- a/.codex/skills/intake-aiwb-goal/SKILL.md
+++ b/.codex/skills/intake-aiwb-goal/SKILL.md
@@ -5,17 +5,18 @@ description: Inspect ticket or draft handoff readiness and the cheapest viable p
 
 # Intake AI Workbench Goal
 
-Use this Skill only at the handoff from accepted tickets or a draft Contract.
-Do not replace `$ask-matt`, grilling, specification, ticket decomposition, TDD,
-architecture review, or small interactive implementation.
+Use this Skill only at the handoff from accepted tickets, a generic planning
+handoff, or a draft Contract. Do not replace `$ask-matt`, grilling,
+specification, ticket decomposition, TDD, architecture review, or small
+interactive implementation.
 
 ## Inspect
 
-Require a repository plus exactly one accepted tickets file or Contract draft.
-Prefer the shared MCP tool:
+Require a repository plus exactly one accepted tickets file, planning handoff,
+or Contract draft. Prefer the shared MCP tool:
 
-- call `aiwb_goal_intake` with `repository` and either `tickets_path` or
-  `contract_path`;
+- call `aiwb_goal_intake` with `repository` and exactly one of `tickets_path`,
+  `handoff_path`, or `contract_path`;
 - optionally include a short task statement when durability or overnight intent
   is not visible in the artifact.
 
@@ -23,8 +24,12 @@ The equivalent local CLI commands are:
 
 ```bash
 aiwb goal intake --repo /path/to/project --tickets /path/to/tickets.md
+aiwb goal intake --repo /path/to/project --handoff /path/to/handoff.json
 aiwb goal intake --repo /path/to/project --contract /path/to/contract.yaml
 ```
+
+Pass the handoff to the shared interface. Do not reimplement schema validation,
+normalization, readiness blockers, or cheapest-path selection in this Skill.
 
 ## Interpret
 

--- a/tools/agent-orchestrator/README.md
+++ b/tools/agent-orchestrator/README.md
@@ -173,6 +173,9 @@ The resource-policy tracer adds:
 The cost-aware Goal intake tracer adds:
 
 - one read-only readiness result for accepted tickets or a draft Contract;
+- a versioned generic planning handoff plus bare issue JSON normalization that
+  preserves source facts without inventing acceptance, Todo, command, or path
+  decisions;
 - a cheapest-path choice that keeps small work in the installed `$ask-matt`
   interactive flow and reserves AI Workbench for durability, multiple Todos,
   Harnesses, recovery, or unattended operation;
@@ -182,6 +185,17 @@ The cost-aware Goal intake tracer adds:
   explicit action through Python, CLI, MCP, and `$intake-aiwb-goal`;
 - no approval, submission, Run, worktree, Agent, Harness, project command, or
   permission side effect during inspection.
+
+The explicit preflight policy tracer adds:
+
+- `--workflow` and `--policy` aliases for a reviewed policy artifact outside
+  the target repository, with matching MCP inputs;
+- separate candidate commands from `suggestions.commands` and approved
+  commands from `capabilities.commands`;
+- exact approved-command matching, with candidate commands remaining advisory;
+- actionable blockers for missing command approval, policy-root mismatch,
+  unapproved policy state, and production targets;
+- the existing repository-local `.ai-workbench/workflow.yaml` default.
 
 The bounded Evidence tracer adds:
 
@@ -273,7 +287,7 @@ Create and activate a Python 3.9+ environment, then install the tool:
 ```bash
 python3 -m venv .venv
 . .venv/bin/activate
-python -m pip install -e .
+python -m pip install -e ".[test]"
 ```
 
 Discover an existing project's capabilities first:
@@ -286,9 +300,73 @@ Review `.ai-workbench/workflow.yaml`, move accepted suggestions into `capabiliti
 
 ```bash
 aiwb doctor --config /path/to/project/.ai-workbench/workflow.yaml
+aiwb goal preflight --contract /path/to/contract.yaml
+aiwb goal preflight --contract /path/to/contract.yaml \
+  --policy /path/to/reviewed-policy.yaml
 ```
 
 `doctor` is not advisory: both direct and Daemon execution load the same project policy before creating a worktree or starting an Agent. The Contract test command must exactly match one approved command, and any production Harness profile is rejected.
+
+Preflight may read an explicit reviewed policy outside the target repository.
+It never writes a repo-local workflow. Candidate commands are reported
+separately and never authorize execution. An unattended Run still uses the
+policy fixed by its Contract.
+
+## Planning Handoff
+
+Planning systems can call the read-only intake boundary without first creating
+AI Workbench-local tickets or a Contract:
+
+```bash
+aiwb goal intake --repo /path/to/project --handoff /path/to/handoff.json
+```
+
+The version 1 envelope is:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "aiwb.planning-handoff",
+  "provenance": {
+    "system": "github",
+    "repository": "owner/repository",
+    "issue": 14
+  },
+  "goal": {
+    "id": "goal-14",
+    "title": "Accept a planning handoff",
+    "requirement": "Preserve the reviewed planning boundary.",
+    "acceptance": [
+      {
+        "id": "AC-1",
+        "statement": "Source provenance is preserved."
+      }
+    ]
+  },
+  "todos": [
+    {
+      "id": "T-1",
+      "title": "Normalize the handoff",
+      "depends_on": [],
+      "acceptance_ids": ["AC-1"]
+    }
+  ]
+}
+```
+
+`provenance` identifies the source system and stable source reference.
+`goal.acceptance` contains only reviewed acceptance statements. `todos` is
+optional planning structure; when present, each Todo declares `depends_on` and
+may map to `acceptance_ids`.
+
+A bare GitHub issue JSON document is also accepted. Intake maps its number,
+title, body, repository URL, and HTML URL into source-preserving Goal fields.
+It leaves acceptance and Todos empty. Intake never invents test commands,
+allowed paths, providers, resources, permissions, or Harness profiles.
+
+Unsupported envelope versions return `unsupported_handoff_schema`. Supported
+but incomplete handoffs return ordinary readiness blockers and warnings.
+Intake remains read-only and does not require a Daemon.
 
 Candidate publication is off by default. To let an overnight Run publish its merge-ready Candidate, review and add this project-owned policy:
 

--- a/tools/agent-orchestrator/setup.cfg
+++ b/tools/agent-orchestrator/setup.cfg
@@ -13,6 +13,10 @@ packages = find:
 install_requires =
     PyYAML>=6.0
 
+[options.extras_require]
+test =
+    pytest>=9.0
+
 [options.packages.find]
 where = src
 

--- a/tools/agent-orchestrator/skills/intake-aiwb-goal/SKILL.md
+++ b/tools/agent-orchestrator/skills/intake-aiwb-goal/SKILL.md
@@ -5,17 +5,18 @@ description: Inspect ticket or draft handoff readiness and the cheapest viable p
 
 # Intake AI Workbench Goal
 
-Use this Skill only at the handoff from accepted tickets or a draft Contract.
-Do not replace `$ask-matt`, grilling, specification, ticket decomposition, TDD,
-architecture review, or small interactive implementation.
+Use this Skill only at the handoff from accepted tickets, a generic planning
+handoff, or a draft Contract. Do not replace `$ask-matt`, grilling,
+specification, ticket decomposition, TDD, architecture review, or small
+interactive implementation.
 
 ## Inspect
 
-Require a repository plus exactly one accepted tickets file or Contract draft.
-Prefer the shared MCP tool:
+Require a repository plus exactly one accepted tickets file, planning handoff,
+or Contract draft. Prefer the shared MCP tool:
 
-- call `aiwb_goal_intake` with `repository` and either `tickets_path` or
-  `contract_path`;
+- call `aiwb_goal_intake` with `repository` and exactly one of `tickets_path`,
+  `handoff_path`, or `contract_path`;
 - optionally include a short task statement when durability or overnight intent
   is not visible in the artifact.
 
@@ -23,8 +24,12 @@ The equivalent local CLI commands are:
 
 ```bash
 aiwb goal intake --repo /path/to/project --tickets /path/to/tickets.md
+aiwb goal intake --repo /path/to/project --handoff /path/to/handoff.json
 aiwb goal intake --repo /path/to/project --contract /path/to/contract.yaml
 ```
+
+Pass the handoff to the shared interface. Do not reimplement schema validation,
+normalization, readiness blockers, or cheapest-path selection in this Skill.
 
 ## Interpret
 

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -132,6 +132,7 @@ def _build_parser() -> argparse.ArgumentParser:
     intake_source = intake.add_mutually_exclusive_group(required=True)
     intake_source.add_argument("--contract", type=Path)
     intake_source.add_argument("--tickets", type=Path)
+    intake_source.add_argument("--handoff", type=Path)
     intake.add_argument("--task", default="")
     _add_control_options(intake)
 
@@ -142,6 +143,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
     preflight = goal_commands.add_parser("preflight")
     preflight.add_argument("--contract", required=True, type=Path)
+    preflight_policy = preflight.add_mutually_exclusive_group()
+    preflight_policy.add_argument("--workflow", type=Path)
+    preflight_policy.add_argument("--policy", dest="workflow", type=Path)
 
     draft = goal_commands.add_parser("draft")
     draft.add_argument("--repo", required=True, type=Path)
@@ -289,7 +293,12 @@ def _run_goal(options: argparse.Namespace) -> int:
         _print_json(result.__dict__)
         return 0
     if options.goal_command == "preflight":
-        _print_json(preview_execution(options.contract).to_dict())
+        _print_json(
+            preview_execution(
+                options.contract,
+                workflow_path=options.workflow,
+            ).to_dict()
+        )
         return 0
     if options.goal_command == "intake":
         client = DaemonClient(_socket_path(options))
@@ -297,6 +306,7 @@ def _run_goal(options: argparse.Namespace) -> int:
             repository=options.repo,
             contract_path=options.contract,
             tickets_path=options.tickets,
+            handoff_path=options.handoff,
             task=options.task,
         )
         _print_json(result.to_dict())

--- a/tools/agent-orchestrator/src/aiwb/intake.py
+++ b/tools/agent-orchestrator/src/aiwb/intake.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Callable, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urlparse
 
 import yaml
 
@@ -43,6 +44,8 @@ class GoalIntakeResult:
     daemon_status: str
     approval_required: bool
     submission_required: bool
+    planning_handoff: Mapping[str, object] = field(default_factory=dict)
+    warnings: Tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -55,6 +58,8 @@ class GoalIntakeResult:
             "daemon_status": self.daemon_status,
             "approval_required": self.approval_required,
             "submission_required": self.submission_required,
+            "planning_handoff": dict(self.planning_handoff),
+            "warnings": list(self.warnings),
         }
 
 
@@ -76,13 +81,23 @@ class GoalIntake:
         repository: Path,
         contract_path: Optional[Path] = None,
         tickets_path: Optional[Path] = None,
+        handoff_path: Optional[Path] = None,
         task: str = "",
     ) -> GoalIntakeResult:
         repository = Path(repository).expanduser().resolve()
         if not repository.is_dir():
             raise ValueError(f"repository is not a directory: {repository}")
-        if (contract_path is None) == (tickets_path is None):
-            raise ValueError("intake requires exactly one Contract or tickets path")
+        sources = tuple(
+            path
+            for path in (contract_path, tickets_path, handoff_path)
+            if path is not None
+        )
+        if len(sources) != 1:
+            raise ValueError(
+                "intake requires exactly one Contract, tickets, or handoff path"
+            )
+        if handoff_path is not None:
+            return self._inspect_handoff(repository, Path(handoff_path))
         daemon_status = "ok" if self._daemon_probe() else "unavailable"
         if tickets_path is not None:
             return self._inspect_tickets(
@@ -96,6 +111,221 @@ class GoalIntake:
             Path(contract_path),
             task,
             daemon_status,
+        )
+
+    def _inspect_handoff(
+        self,
+        repository: Path,
+        handoff_path: Path,
+    ) -> GoalIntakeResult:
+        try:
+            data = _read_mapping(handoff_path, "planning handoff")
+        except ValueError as error:
+            blocker = IntakeBlocker(
+                code="handoff_validation",
+                message=str(error),
+                action=(
+                    "Provide valid JSON using aiwb.planning-handoff "
+                    "schema_version 1 or a bare issue document."
+                ),
+            )
+            return GoalIntakeResult(
+                source="handoff",
+                readiness="blocked",
+                cheapest_viable_path="undetermined",
+                blockers=(blocker,),
+                execution_envelope={},
+                next_action="resolve_handoff_blockers",
+                daemon_status="not_required",
+                approval_required=False,
+                submission_required=False,
+            )
+        if data.get("kind") == "aiwb.planning-handoff":
+            if data.get("schema_version") != 1:
+                blocker = IntakeBlocker(
+                    code="unsupported_handoff_schema",
+                    message=(
+                        "Planning handoff schema_version is unsupported: "
+                        f"{data.get('schema_version')!r}."
+                    ),
+                    action=(
+                        "Provide aiwb.planning-handoff schema_version 1 or a "
+                        "bare issue JSON document."
+                    ),
+                )
+                return GoalIntakeResult(
+                    source="handoff",
+                    readiness="blocked",
+                    cheapest_viable_path="undetermined",
+                    blockers=(blocker,),
+                    execution_envelope={},
+                    next_action="use_supported_handoff_schema",
+                    daemon_status="not_required",
+                    approval_required=False,
+                    submission_required=False,
+                )
+            normalized = _normalize_versioned_handoff(data)
+        else:
+            if not _is_bare_issue(data):
+                blocker = IntakeBlocker(
+                    code="handoff_validation",
+                    message=(
+                        "Planning handoff must be a supported versioned envelope "
+                        "or bare issue JSON document."
+                    ),
+                    action=(
+                        "Provide aiwb.planning-handoff schema_version 1 or a "
+                        "bare issue JSON document with number, title, and body."
+                    ),
+                )
+                return GoalIntakeResult(
+                    source="handoff",
+                    readiness="blocked",
+                    cheapest_viable_path="undetermined",
+                    blockers=(blocker,),
+                    execution_envelope={},
+                    next_action="resolve_handoff_blockers",
+                    daemon_status="not_required",
+                    approval_required=False,
+                    submission_required=False,
+                )
+            normalized = _normalize_bare_issue(data)
+        goal = normalized["goal"]
+        acceptance = normalized["acceptance"]
+        todos = tuple(normalized["todos"])
+        handoff_blockers = []
+        warnings = []
+        provenance = normalized["provenance"]
+        if not provenance:
+            handoff_blockers.append(
+                IntakeBlocker(
+                    code="handoff_provenance",
+                    message="The planning handoff does not identify its source.",
+                    action="Add the planning system and stable source reference.",
+                )
+            )
+        todo_ids = {
+            str(todo.get("id"))
+            for todo in todos
+            if isinstance(todo.get("id"), str) and todo.get("id")
+        }
+        dependencies_ok = True
+        for todo in todos:
+            todo_id = str(todo.get("id", "unknown"))
+            dependencies = todo.get("depends_on")
+            if (
+                not isinstance(dependencies, list)
+                or not all(isinstance(item, str) and item for item in dependencies)
+                or set(dependencies) - todo_ids
+            ):
+                dependencies_ok = False
+            acceptance_ids = todo.get("acceptance_ids")
+            if not isinstance(acceptance_ids, list) or not acceptance_ids:
+                warnings.append(f"Todo {todo_id} has no acceptance_ids mapping.")
+        if not dependencies_ok:
+            handoff_blockers.append(
+                IntakeBlocker(
+                    code="todo_dependencies",
+                    message=(
+                        "Planning handoff Todo relationships are incomplete "
+                        "or invalid."
+                    ),
+                    action="Add explicit depends_on lists using known Todo ids.",
+                )
+            )
+        graph = {
+            str(todo["id"]): tuple(
+                item
+                for item in todo.get("depends_on", ())
+                if isinstance(item, str) and item in todo_ids
+            )
+            for todo in todos
+            if isinstance(todo.get("id"), str) and todo.get("id")
+        }
+        try:
+            envelope = preview_todo_graph(
+                goal_id=str(goal.get("id", "handoff-intake-preview")),
+                approval_status="planning",
+                provider="unselected",
+                model=None,
+                todo_dependencies=graph or {"T-1": ()},
+            ).to_dict()
+        except ContractError:
+            handoff_blockers.append(
+                IntakeBlocker(
+                    code="todo_dependencies",
+                    message=(
+                        "Planning handoff Todo relationships must form an "
+                        "acyclic graph."
+                    ),
+                    action="Remove cyclic Todo dependencies and rerun intake.",
+                )
+            )
+            envelope = preview_todo_graph(
+                goal_id=str(goal.get("id", "handoff-intake-preview")),
+                approval_status="planning",
+                provider="unselected",
+                model=None,
+                todo_dependencies={
+                    todo_id: () for todo_id in graph
+                } or {"T-1": ()},
+            ).to_dict()
+        requirement = str(goal.get("requirement", ""))
+        if (
+            acceptance
+            and len(todos) <= 1
+            and not handoff_blockers
+            and not _has_durability_signal(requirement)
+        ):
+            return self._interactive_result(
+                repository,
+                source="handoff",
+                envelope=envelope,
+                daemon_status="not_required",
+                planning_handoff=normalized,
+            )
+        blockers = list(handoff_blockers)
+        blockers.extend(_policy_blockers(repository))
+        if not acceptance:
+            blockers.append(
+                IntakeBlocker(
+                    code="acceptance_boundary",
+                    message=(
+                        "The planning handoff does not contain accepted "
+                        "acceptance criteria."
+                    ),
+                    action=(
+                        "Review and add acceptance criteria before drafting "
+                        "a Contract."
+                    ),
+                )
+            )
+        blockers.append(
+            IntakeBlocker(
+                code="contract_draft",
+                message=(
+                    "A planning handoff needs a reviewed Contract draft before "
+                    "unattended readiness can be decided."
+                ),
+                action="Create a Contract draft from the preserved planning handoff.",
+            )
+        )
+        return GoalIntakeResult(
+            source="handoff",
+            readiness="blocked",
+            cheapest_viable_path="ai_workbench_unattended",
+            blockers=_dedupe(blockers),
+            execution_envelope=envelope,
+            next_action=(
+                "resolve_handoff_blockers"
+                if handoff_blockers or not acceptance
+                else "create_contract_draft"
+            ),
+            daemon_status="not_required",
+            approval_required=True,
+            submission_required=True,
+            planning_handoff=normalized,
+            warnings=tuple(warnings),
         )
 
     def _inspect_tickets(
@@ -268,6 +498,7 @@ class GoalIntake:
         source: str,
         envelope: Mapping[str, object],
         daemon_status: str,
+        planning_handoff: Optional[Mapping[str, object]] = None,
     ) -> GoalIntakeResult:
         ask_matt = any(
             skill.name == "ask-matt"
@@ -285,6 +516,7 @@ class GoalIntake:
             daemon_status=daemon_status,
             approval_required=False,
             submission_required=False,
+            planning_handoff=planning_handoff or {},
         )
 
 
@@ -533,6 +765,88 @@ def _contains_production(value: object) -> bool:
     if isinstance(value, list):
         return any(_contains_production(item) for item in value)
     return isinstance(value, str) and value.strip().lower() == "production"
+
+
+def _normalize_versioned_handoff(
+    data: Mapping[str, object],
+) -> Mapping[str, object]:
+    goal = data.get("goal")
+    goal = goal if isinstance(goal, dict) else {}
+    acceptance = goal.get("acceptance")
+    acceptance = acceptance if isinstance(acceptance, list) else []
+    todos = data.get("todos")
+    todos = todos if isinstance(todos, list) else []
+    provenance = data.get("provenance")
+    provenance = provenance if isinstance(provenance, dict) else {}
+    return {
+        "schema_version": data.get("schema_version"),
+        "kind": data.get("kind"),
+        "format": "versioned",
+        "provenance": dict(provenance),
+        "goal": {
+            key: goal[key]
+            for key in ("id", "title", "requirement")
+            if key in goal
+        },
+        "acceptance": [
+            dict(item) for item in acceptance if isinstance(item, dict)
+        ],
+        "todos": [dict(item) for item in todos if isinstance(item, dict)],
+    }
+
+
+def _normalize_bare_issue(data: Mapping[str, object]) -> Mapping[str, object]:
+    number = data.get("number")
+    title = data.get("title")
+    body = data.get("body")
+    html_url = data.get("html_url", data.get("url"))
+    repository_url = data.get("repository_url")
+    repository_name = ""
+    if isinstance(repository_url, str):
+        marker = "/repos/"
+        parsed_path = urlparse(repository_url).path
+        if marker in parsed_path:
+            repository_name = parsed_path.split(marker, 1)[1].strip("/")
+    if not repository_name and isinstance(html_url, str):
+        parts = tuple(
+            part for part in urlparse(html_url).path.split("/") if part
+        )
+        if len(parts) >= 4 and parts[2] == "issues":
+            repository_name = "/".join(parts[:2])
+    issue_id = (
+        f"github:{repository_name}#{number}"
+        if repository_name and isinstance(number, int)
+        else "github:issue"
+    )
+    provenance = {"system": "github"}
+    if repository_name:
+        provenance["repository"] = repository_name
+    if isinstance(number, int):
+        provenance["issue"] = number
+    if isinstance(html_url, str) and html_url:
+        provenance["url"] = html_url
+    return {
+        "schema_version": 1,
+        "kind": "aiwb.planning-handoff",
+        "format": "bare_issue",
+        "provenance": provenance,
+        "goal": {
+            "id": issue_id,
+            **({"title": title} if isinstance(title, str) else {}),
+            **({"requirement": body} if isinstance(body, str) else {}),
+        },
+        "acceptance": [],
+        "todos": [],
+    }
+
+
+def _is_bare_issue(data: Mapping[str, object]) -> bool:
+    return (
+        isinstance(data.get("number"), int)
+        and isinstance(data.get("title"), str)
+        and bool(str(data["title"]).strip())
+        and isinstance(data.get("body"), str)
+    )
 
 
 def _read_mapping(path: Path, name: str) -> Mapping[str, object]:

--- a/tools/agent-orchestrator/src/aiwb/mcp_server.py
+++ b/tools/agent-orchestrator/src/aiwb/mcp_server.py
@@ -93,14 +93,43 @@ class McpServer:
                 }
             elif name == "aiwb_goal_preflight":
                 contract_path = _string_argument(arguments, "contract_path")
-                value = preview_execution(Path(contract_path)).to_dict()
+                workflow_path = arguments.get("workflow_path")
+                policy_path = arguments.get("policy_path")
+                if workflow_path is not None and policy_path is not None:
+                    raise ValueError(
+                        "preflight accepts only one workflow_path or policy_path"
+                    )
+                selected_path = (
+                    workflow_path if workflow_path is not None else policy_path
+                )
+                if selected_path is not None and (
+                    not isinstance(selected_path, str) or not selected_path
+                ):
+                    raise ValueError(
+                        "workflow_path or policy_path must be a non-empty string"
+                    )
+                value = preview_execution(
+                    Path(contract_path),
+                    workflow_path=(
+                        Path(selected_path)
+                        if isinstance(selected_path, str)
+                        else None
+                    ),
+                ).to_dict()
             elif name == "aiwb_goal_intake":
                 repository = _string_argument(arguments, "repository")
                 contract_path = arguments.get("contract_path")
                 tickets_path = arguments.get("tickets_path")
-                if (contract_path is None) == (tickets_path is None):
+                handoff_path = arguments.get("handoff_path")
+                sources = tuple(
+                    value
+                    for value in (contract_path, tickets_path, handoff_path)
+                    if value is not None
+                )
+                if len(sources) != 1:
                     raise ValueError(
-                        "intake requires exactly one contract_path or tickets_path"
+                        "intake requires exactly one contract_path, tickets_path, "
+                        "or handoff_path"
                     )
                 task = arguments.get("task", "")
                 if not isinstance(task, str):
@@ -115,6 +144,11 @@ class McpServer:
                     tickets_path=(
                         Path(tickets_path)
                         if isinstance(tickets_path, str) and tickets_path
+                        else None
+                    ),
+                    handoff_path=(
+                        Path(handoff_path)
+                        if isinstance(handoff_path, str) and handoff_path
                         else None
                     ),
                     task=task,
@@ -178,8 +212,8 @@ def _tools():
         {
             "name": "aiwb_goal_intake",
             "description": (
-                "Inspect accepted tickets or a draft Contract and recommend the "
-                "cheapest viable interactive or unattended path without taking action."
+                "Inspect accepted tickets, a planning handoff, or a draft Contract "
+                "and recommend the cheapest viable path without taking action."
             ),
             "inputSchema": {
                 "type": "object",
@@ -187,6 +221,7 @@ def _tools():
                     "repository": string_argument,
                     "contract_path": string_argument,
                     "tickets_path": string_argument,
+                    "handoff_path": string_argument,
                     "task": {"type": "string"},
                 },
                 "required": ["repository"],
@@ -197,11 +232,16 @@ def _tools():
             "name": "aiwb_goal_preflight",
             "description": (
                 "Preview the deterministic and conditional execution envelope "
-                "for a draft or approved Contract without creating a Run."
+                "for a Contract against its repository policy or an explicit "
+                "reviewed policy artifact without creating a Run."
             ),
             "inputSchema": {
                 "type": "object",
-                "properties": {"contract_path": string_argument},
+                "properties": {
+                    "contract_path": string_argument,
+                    "workflow_path": string_argument,
+                    "policy_path": string_argument,
+                },
                 "required": ["contract_path"],
                 "additionalProperties": False,
             },

--- a/tools/agent-orchestrator/src/aiwb/project.py
+++ b/tools/agent-orchestrator/src/aiwb/project.py
@@ -85,6 +85,7 @@ class CandidatePublishProfile:
 @dataclass(frozen=True)
 class ProjectPolicy:
     repository: Path
+    candidate_commands: Tuple[Mapping[str, object], ...]
     approved_commands: Tuple[Tuple[str, ...], ...]
     role_skill_texts: Mapping[str, Tuple[Tuple[str, str], ...]]
     harness_profiles: Mapping[str, HarnessProfile]
@@ -118,6 +119,7 @@ class ProjectPolicy:
         capabilities = data.get("capabilities")
         if not isinstance(capabilities, dict):
             raise ProjectConfigError("project policy capabilities must be a mapping")
+        candidate_commands = _load_candidate_commands(data)
         commands = capabilities.get("commands")
         if not isinstance(commands, dict) or not commands:
             raise ProjectConfigError("project policy requires an approved command")
@@ -145,6 +147,7 @@ class ProjectPolicy:
         candidate_publish = _load_candidate_publish_profile(data)
         return cls(
             repository=repository,
+            candidate_commands=candidate_commands,
             approved_commands=tuple(approved_commands),
             role_skill_texts=role_skill_texts,
             harness_profiles=harness_profiles,
@@ -211,6 +214,33 @@ class ProjectPolicy:
                 f"Candidate publishing remote is not configured: {profile.remote}"
             )
         return profile
+
+
+def _load_candidate_commands(
+    data: Mapping[str, object],
+) -> Tuple[Mapping[str, object], ...]:
+    suggestions = data.get("suggestions", {})
+    if not isinstance(suggestions, dict):
+        raise ProjectConfigError("suggestions must be a mapping")
+    commands = suggestions.get("commands", {})
+    if not isinstance(commands, dict):
+        return ()
+    result = []
+    for name, definition in commands.items():
+        if not isinstance(name, str) or not name or not isinstance(definition, dict):
+            continue
+        argv = definition.get("argv")
+        if (
+            not isinstance(argv, list)
+            or not argv
+            or not all(isinstance(item, str) and item for item in argv)
+        ):
+            continue
+        reason = definition.get("reason", "")
+        if not isinstance(reason, str):
+            continue
+        result.append({"name": name, "argv": list(argv), "reason": reason})
+    return tuple(result)
 
 
 def _load_role_skill_texts(

--- a/tools/agent-orchestrator/src/aiwb/runner.py
+++ b/tools/agent-orchestrator/src/aiwb/runner.py
@@ -100,6 +100,8 @@ class _Contract:
     image_profile: Optional[ImageProfile]
     candidate_publish: Optional[CandidatePublishProfile]
     role_skill_texts: Mapping[str, Tuple[Tuple[str, str], ...]]
+    policy: Mapping[str, object]
+    policy_blockers: Tuple[Mapping[str, str], ...]
 
     @property
     def run_id(self) -> str:
@@ -187,6 +189,9 @@ class ExecutionEnvelope:
     monetary_cost: Mapping[str, object]
     resource_boundaries: Mapping[str, object]
     concurrency_explanation: str
+    policy: Mapping[str, object] = field(default_factory=dict)
+    readiness: str = "ready"
+    blockers: Tuple[Mapping[str, str], ...] = ()
 
     def to_dict(self) -> Dict[str, object]:
         return {
@@ -204,6 +209,9 @@ class ExecutionEnvelope:
             "monetary_cost": dict(self.monetary_cost),
             "resource_boundaries": dict(self.resource_boundaries),
             "concurrency_explanation": self.concurrency_explanation,
+            "policy": dict(self.policy),
+            "readiness": self.readiness,
+            "blockers": [dict(blocker) for blocker in self.blockers],
         }
 
 
@@ -334,11 +342,16 @@ class RunReport:
         )
 
 
-def preview_execution(contract_path: Path) -> ExecutionEnvelope:
+def preview_execution(
+    contract_path: Path,
+    workflow_path: Optional[Path] = None,
+) -> ExecutionEnvelope:
     """Preview an authorized Contract without creating execution state."""
     contract = _load_contract(
         Path(contract_path).expanduser().resolve(),
         require_approval=False,
+        workflow_path=workflow_path,
+        preflight=True,
     )
     return _execution_envelope(contract)
 
@@ -2449,6 +2462,8 @@ def _load_contract(
     path: Path,
     *,
     require_approval: bool = True,
+    workflow_path: Optional[Path] = None,
+    preflight: bool = False,
 ) -> _Contract:
     raw = path.read_bytes()
     try:
@@ -2517,11 +2532,19 @@ def _load_contract(
     image_profile_name = candidate.get("image_profile", "")
     if not isinstance(image_profile_name, str):
         raise ContractError("candidate.image_profile must be a profile name")
-    todos, image_profile, candidate_publish, role_skill_texts = _authorize_contract(
+    (
+        todos,
+        image_profile,
+        candidate_publish,
+        role_skill_texts,
+        policy_metadata,
+    ) = _authorize_contract(
         project,
         repository,
         todos,
         image_profile_name,
+        workflow_path=workflow_path,
+        preflight=preflight,
     )
     resources = _parse_resources(data.get("resources", {}))
 
@@ -2542,6 +2565,12 @@ def _load_contract(
         image_profile=image_profile,
         candidate_publish=candidate_publish,
         role_skill_texts=role_skill_texts,
+        policy={
+            key: value
+            for key, value in policy_metadata.items()
+            if key != "blockers"
+        },
+        policy_blockers=tuple(policy_metadata.get("blockers", ())),
     )
 
 
@@ -2591,44 +2620,242 @@ def _authorize_contract(
     repository: Path,
     todos: Sequence[_Todo],
     image_profile_name: str,
+    *,
+    workflow_path: Optional[Path] = None,
+    preflight: bool = False,
 ) -> Tuple[
     Tuple[_Todo, ...],
     Optional[ImageProfile],
     Optional[CandidatePublishProfile],
     Mapping[str, Tuple[Tuple[str, str], ...]],
+    Mapping[str, object],
 ]:
-    workflow_value = project.get("workflow", ".ai-workbench/workflow.yaml")
-    if not isinstance(workflow_value, str) or not workflow_value:
-        raise ContractError("project.workflow must be a non-empty path")
-    workflow_path = Path(workflow_value).expanduser()
-    if not workflow_path.is_absolute():
-        workflow_path = repository / workflow_path
-    workflow_path = workflow_path.resolve()
+    explicit = workflow_path is not None
+    if explicit:
+        resolved_workflow_path = Path(workflow_path).expanduser().resolve()
+    else:
+        workflow_value = project.get("workflow", ".ai-workbench/workflow.yaml")
+        if not isinstance(workflow_value, str) or not workflow_value:
+            raise ContractError("project.workflow must be a non-empty path")
+        resolved_workflow_path = Path(workflow_value).expanduser()
+        if not resolved_workflow_path.is_absolute():
+            resolved_workflow_path = repository / resolved_workflow_path
+        resolved_workflow_path = resolved_workflow_path.resolve()
+        try:
+            resolved_workflow_path.relative_to(repository)
+        except ValueError as error:
+            raise ContractError(
+                "project.workflow must stay inside project.repo"
+            ) from error
     try:
-        workflow_path.relative_to(repository)
-    except ValueError as error:
-        raise ContractError("project.workflow must stay inside project.repo") from error
-    try:
-        policy = ProjectPolicy.load(workflow_path)
-        authorized_todos = tuple(
-            replace(
-                todo,
-                harness=policy.authorize(
-                    repository,
-                    todo.test_command,
-                    todo.harness_name,
-                ),
+        policy = ProjectPolicy.load(resolved_workflow_path)
+        blockers = []
+        authorized_todos = []
+        root_mismatch = policy.repository != repository
+        if preflight and root_mismatch:
+            blockers.append(
+                {
+                    "code": "policy_root_mismatch",
+                    "message": (
+                        "The selected policy root does not match the Contract "
+                        "repository."
+                    ),
+                    "action": (
+                        f"Review {resolved_workflow_path} and set project.root to "
+                        f"{repository}."
+                    ),
+                }
             )
-            for todo in todos
-        )
+            authorized_todos.extend(todos)
+        else:
+            for todo in todos:
+                try:
+                    harness = policy.authorize(
+                        repository,
+                        todo.test_command,
+                        todo.harness_name,
+                    )
+                except ProjectConfigError as error:
+                    if (
+                        preflight
+                        and str(error)
+                        == "Contract test command is not an approved project capability"
+                    ):
+                        blockers.append(
+                            {
+                                "code": "approved_command_missing",
+                                "message": (
+                                    f"Contract Todo {todo.todo_id} test command is not "
+                                    "exactly approved by the selected policy."
+                                ),
+                                "action": (
+                                    "Review and add the exact command to "
+                                    f"{resolved_workflow_path} capabilities.commands "
+                                    "with approved: true."
+                                ),
+                            }
+                        )
+                        harness = None
+                    else:
+                        raise
+                authorized_todos.append(replace(todo, harness=harness))
         return (
-            authorized_todos,
+            tuple(authorized_todos),
             policy.authorize_image(image_profile_name),
             policy.authorize_publish(repository),
             policy.role_skill_texts,
+            {
+                "path": str(resolved_workflow_path),
+                "source": "explicit" if explicit else "repository",
+                "candidate_commands": [
+                    dict(command) for command in policy.candidate_commands
+                ],
+                "approved_commands": [
+                    list(command) for command in policy.approved_commands
+                ],
+                "blockers": blockers,
+            },
         )
     except ProjectConfigError as error:
+        blocker = _preflight_policy_error(
+            error,
+            resolved_workflow_path,
+        ) if preflight else None
+        if blocker is not None:
+            return _blocked_preflight_authorization(
+                todos=todos,
+                path=resolved_workflow_path,
+                explicit=explicit,
+                blocker=blocker,
+            )
         raise ContractError(str(error)) from error
+
+
+def _preflight_policy_error(
+    error: ProjectConfigError,
+    path: Path,
+) -> Optional[Mapping[str, str]]:
+    message = str(error)
+    if (
+        message == "project policy requires an approved command"
+        or (
+            message.startswith("project command ")
+            and message.endswith(" must be approved")
+        )
+    ):
+        return {
+            "code": "approved_command_missing",
+            "message": message,
+            "action": (
+                "Review and add the exact Contract test command to "
+                f"{path} capabilities.commands with approved: true."
+            ),
+        }
+    if message in {
+        "project policy status must be approved",
+        "project must be explicitly trusted",
+    }:
+        return {
+            "code": "policy_not_approved",
+            "message": message,
+            "action": (
+                f"Review {path}, explicitly approve its trusted project and "
+                "capabilities, then rerun preflight."
+            ),
+        }
+    if message.startswith(
+        (
+            "production Harness profile is forbidden:",
+            "production image profile is forbidden:",
+        )
+    ):
+        return {
+            "code": "production_target",
+            "message": message,
+            "action": (
+                f"Review {path} and use only local or non-production "
+                "Harness and image profiles."
+            ),
+        }
+    return None
+
+
+def _blocked_preflight_authorization(
+    *,
+    todos: Sequence[_Todo],
+    path: Path,
+    explicit: bool,
+    blocker: Mapping[str, str],
+) -> Tuple[
+    Tuple[_Todo, ...],
+    Optional[ImageProfile],
+    Optional[CandidatePublishProfile],
+    Mapping[str, Tuple[Tuple[str, str], ...]],
+    Mapping[str, object],
+]:
+    return (
+        tuple(todos),
+        None,
+        None,
+        {},
+        {
+            **_policy_display_metadata(
+                _read_policy_mapping(path),
+                path,
+                explicit,
+            ),
+            "blockers": [dict(blocker)],
+        },
+    )
+
+
+def _read_policy_mapping(path: Path) -> Mapping[str, object]:
+    try:
+        value = yaml.safe_load(path.read_bytes())
+    except (OSError, yaml.YAMLError) as error:
+        raise ContractError(f"cannot read project policy: {error}") from error
+    if not isinstance(value, dict):
+        raise ContractError("project policy must be a YAML mapping")
+    return value
+
+
+def _policy_display_metadata(
+    data: Mapping[str, object],
+    path: Path,
+    explicit: bool,
+) -> Mapping[str, object]:
+    suggestions = data.get("suggestions")
+    suggestions = suggestions if isinstance(suggestions, dict) else {}
+    candidate_values = suggestions.get("commands")
+    candidate_values = (
+        candidate_values if isinstance(candidate_values, dict) else {}
+    )
+    candidates = []
+    for name, definition in candidate_values.items():
+        if isinstance(name, str) and isinstance(definition, dict):
+            argv = definition.get("argv")
+            reason = definition.get("reason", "")
+            if isinstance(argv, list) and isinstance(reason, str):
+                candidates.append(
+                    {"name": name, "argv": list(argv), "reason": reason}
+                )
+    capabilities = data.get("capabilities")
+    capabilities = capabilities if isinstance(capabilities, dict) else {}
+    command_values = capabilities.get("commands")
+    command_values = command_values if isinstance(command_values, dict) else {}
+    approved = [
+        list(definition["argv"])
+        for definition in command_values.values()
+        if isinstance(definition, dict)
+        and definition.get("approved") is True
+        and isinstance(definition.get("argv"), list)
+    ]
+    return {
+        "path": str(path),
+        "source": "explicit" if explicit else "repository",
+        "candidate_commands": candidates,
+        "approved_commands": approved,
+    }
 
 
 def _contract_hash(
@@ -2698,7 +2925,7 @@ def _validate_todo_dag(
 
 
 def _execution_envelope(contract: _Contract) -> ExecutionEnvelope:
-    return _execution_envelope_from_graph(
+    envelope = _execution_envelope_from_graph(
         goal_id=contract.goal_id,
         approval_status=contract.approval_status,
         provider=contract.agent_provider,
@@ -2714,6 +2941,12 @@ def _execution_envelope(contract: _Contract) -> ExecutionEnvelope:
         ),
         image_build_configured=contract.image_profile is not None,
         candidate_publish_configured=contract.candidate_publish is not None,
+    )
+    return replace(
+        envelope,
+        policy=contract.policy,
+        readiness="blocked" if contract.policy_blockers else "ready",
+        blockers=contract.policy_blockers,
     )
 
 

--- a/tools/agent-orchestrator/tests/test_goal_intake.py
+++ b/tools/agent-orchestrator/tests/test_goal_intake.py
@@ -203,6 +203,616 @@ def test_accepted_tickets_choose_interactive_or_contract_handoff_by_shape() -> N
         ] == 7
 
 
+def test_multi_todo_planning_handoff_preserves_source_and_planning_boundaries() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {
+                        "system": "github",
+                        "repository": "blackfaced/ai-workbench",
+                        "issue": 14,
+                    },
+                    "goal": {
+                        "id": "goal-14",
+                        "title": "Accept generic planning handoffs",
+                        "requirement": "Preserve a reviewed planning handoff.",
+                        "acceptance": [
+                            {
+                                "id": "AC-1",
+                                "statement": "The source provenance is preserved.",
+                            },
+                            {
+                                "id": "AC-2",
+                                "statement": "Todo dependencies are preserved.",
+                            },
+                        ],
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "Normalize the handoff",
+                            "depends_on": [],
+                            "acceptance_ids": ["AC-1"],
+                        },
+                        {
+                            "id": "T-2",
+                            "title": "Expose intake semantics",
+                            "depends_on": ["T-1"],
+                            "acceptance_ids": ["AC-2"],
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        before = _tree(root)
+
+        result = GoalIntake(
+            daemon_probe=lambda: (_ for _ in ()).throw(
+                AssertionError("planning handoff intake must not require a daemon")
+            )
+        ).inspect(
+            repository=repository,
+            handoff_path=handoff,
+        )
+
+        assert _tree(root) == before
+        assert result.source == "handoff"
+        assert result.readiness == "blocked"
+        assert result.cheapest_viable_path == "ai_workbench_unattended"
+        assert result.next_action == "create_contract_draft"
+        assert result.daemon_status == "not_required"
+        assert result.planning_handoff == {
+            "schema_version": 1,
+            "kind": "aiwb.planning-handoff",
+            "format": "versioned",
+            "provenance": {
+                "system": "github",
+                "repository": "blackfaced/ai-workbench",
+                "issue": 14,
+            },
+            "goal": {
+                "id": "goal-14",
+                "title": "Accept generic planning handoffs",
+                "requirement": "Preserve a reviewed planning handoff.",
+            },
+            "acceptance": [
+                {
+                    "id": "AC-1",
+                    "statement": "The source provenance is preserved.",
+                },
+                {
+                    "id": "AC-2",
+                    "statement": "Todo dependencies are preserved.",
+                },
+            ],
+            "todos": [
+                {
+                    "id": "T-1",
+                    "title": "Normalize the handoff",
+                    "depends_on": [],
+                    "acceptance_ids": ["AC-1"],
+                },
+                {
+                    "id": "T-2",
+                    "title": "Expose intake semantics",
+                    "depends_on": ["T-1"],
+                    "acceptance_ids": ["AC-2"],
+                },
+            ],
+        }
+        assert result.warnings == ()
+        assert {item.code for item in result.blockers} == {"contract_draft"}
+        assert result.execution_envelope["layers"] == [["T-1"], ["T-2"]]
+
+
+def test_bare_issue_json_is_normalized_without_inventing_planning_details() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        issue = root / "issue.json"
+        issue.write_text(
+            json.dumps(
+                {
+                    "number": 14,
+                    "title": "Accept generic planning handoffs at Goal intake",
+                    "body": "Preserve this issue as planning source material.",
+                    "html_url": (
+                        "https://github.com/blackfaced/ai-workbench/issues/14"
+                    ),
+                    "repository_url": (
+                        "https://api.github.com/repos/blackfaced/ai-workbench"
+                    ),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = GoalIntake().inspect(
+            repository=repository,
+            handoff_path=issue,
+        )
+
+        assert result.planning_handoff == {
+            "schema_version": 1,
+            "kind": "aiwb.planning-handoff",
+            "format": "bare_issue",
+            "provenance": {
+                "system": "github",
+                "repository": "blackfaced/ai-workbench",
+                "issue": 14,
+                "url": "https://github.com/blackfaced/ai-workbench/issues/14",
+            },
+            "goal": {
+                "id": "github:blackfaced/ai-workbench#14",
+                "title": "Accept generic planning handoffs at Goal intake",
+                "requirement": "Preserve this issue as planning source material.",
+            },
+            "acceptance": [],
+            "todos": [],
+        }
+        assert {item.code for item in result.blockers} == {
+            "acceptance_boundary",
+            "contract_draft",
+        }
+        assert result.execution_envelope["layers"] == [["T-1"]]
+
+
+def test_gh_cli_issue_json_preserves_repository_provenance_from_url() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        issue = root / "gh-issue.json"
+        issue.write_text(
+            json.dumps(
+                {
+                    "number": 15,
+                    "title": "Use an explicit reviewed policy",
+                    "body": "Preflight against a reviewed policy artifact.",
+                    "url": "https://github.com/blackfaced/ai-workbench/issues/15",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = GoalIntake().inspect(
+            repository=repository,
+            handoff_path=issue,
+        )
+
+        assert result.planning_handoff["provenance"] == {
+            "system": "github",
+            "repository": "blackfaced/ai-workbench",
+            "issue": 15,
+            "url": "https://github.com/blackfaced/ai-workbench/issues/15",
+        }
+        assert result.planning_handoff["goal"]["id"] == (
+            "github:blackfaced/ai-workbench#15"
+        )
+
+
+def test_small_planning_handoff_stays_in_the_installed_matt_flow() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        _install_ask_matt(repository)
+        handoff = root / "small-handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {"system": "local", "reference": "note-1"},
+                    "goal": {
+                        "id": "small-goal",
+                        "title": "Correct one label",
+                        "requirement": "Correct one label in the CLI output.",
+                        "acceptance": [
+                            {
+                                "id": "AC-1",
+                                "statement": "The corrected label is shown.",
+                            }
+                        ],
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "Correct the label",
+                            "depends_on": [],
+                            "acceptance_ids": ["AC-1"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = GoalIntake(
+            daemon_probe=lambda: (_ for _ in ()).throw(
+                AssertionError("interactive handoff intake must not require a daemon")
+            )
+        ).inspect(
+            repository=repository,
+            handoff_path=handoff,
+        )
+
+        assert result.readiness == "interactive"
+        assert result.cheapest_viable_path == "interactive_matt"
+        assert result.blockers == ()
+        assert result.next_action == "invoke_ask_matt"
+        assert result.daemon_status == "not_required"
+        assert result.approval_required is False
+        assert result.submission_required is False
+        assert result.planning_handoff["goal"]["id"] == "small-goal"
+
+
+def test_small_planning_handoff_can_omit_todo_structure() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        _install_ask_matt(repository)
+        handoff = root / "small-goal-only-handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {"system": "local", "reference": "note-2"},
+                    "goal": {
+                        "id": "small-goal-only",
+                        "title": "Correct one label",
+                        "requirement": "Correct one label in the CLI output.",
+                        "acceptance": [
+                            {
+                                "id": "AC-1",
+                                "statement": "The corrected label is shown.",
+                            }
+                        ],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = GoalIntake().inspect(
+            repository=repository,
+            handoff_path=handoff,
+        )
+
+        assert result.readiness == "interactive"
+        assert result.next_action == "invoke_ask_matt"
+        assert result.blockers == ()
+        assert result.planning_handoff["todos"] == []
+
+
+def test_unsupported_planning_handoff_schema_returns_an_actionable_blocker() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "future-handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {"system": "planner", "reference": "future-1"},
+                    "goal": {
+                        "id": "future-goal",
+                        "title": "Use a future handoff",
+                        "requirement": "Exercise a future schema.",
+                        "acceptance": [
+                            {"id": "AC-1", "statement": "The handoff is accepted."}
+                        ],
+                    },
+                    "todos": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = GoalIntake().inspect(
+            repository=repository,
+            handoff_path=handoff,
+        )
+
+        assert result.readiness == "blocked"
+        assert result.next_action == "use_supported_handoff_schema"
+        assert result.planning_handoff == {}
+        assert result.warnings == ()
+        assert [item.code for item in result.blockers] == [
+            "unsupported_handoff_schema"
+        ]
+        assert result.blockers[0].action == (
+            "Provide aiwb.planning-handoff schema_version 1 or a bare issue JSON document."
+        )
+
+
+def test_incomplete_planning_handoff_returns_readiness_blockers_and_warnings() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "incomplete-handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "goal": {
+                        "id": "incomplete-goal",
+                        "title": "Incomplete planning handoff",
+                        "requirement": "Retain the known planning facts.",
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "Known Todo",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = GoalIntake().inspect(
+            repository=repository,
+            handoff_path=handoff,
+        )
+
+        assert result.readiness == "blocked"
+        assert result.next_action == "resolve_handoff_blockers"
+        assert {item.code for item in result.blockers} == {
+            "acceptance_boundary",
+            "contract_draft",
+            "handoff_provenance",
+            "todo_dependencies",
+        }
+        assert result.warnings == (
+            "Todo T-1 has no acceptance_ids mapping.",
+        )
+        assert result.planning_handoff["goal"]["id"] == "incomplete-goal"
+        assert result.planning_handoff["acceptance"] == []
+        assert result.planning_handoff["todos"] == [
+            {"id": "T-1", "title": "Known Todo"}
+        ]
+
+
+def test_invalid_small_handoff_does_not_bypass_readiness_for_interactive_path() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        _install_ask_matt(repository)
+        handoff = root / "invalid-small-handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "goal": {
+                        "id": "small-invalid",
+                        "title": "Small but incomplete",
+                        "requirement": "Make one small change.",
+                        "acceptance": [
+                            {"id": "AC-1", "statement": "The change works."}
+                        ],
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "Make the change",
+                            "acceptance_ids": ["AC-1"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = GoalIntake().inspect(
+            repository=repository,
+            handoff_path=handoff,
+        )
+
+        assert result.readiness == "blocked"
+        assert result.next_action == "resolve_handoff_blockers"
+        assert {item.code for item in result.blockers} >= {
+            "handoff_provenance",
+            "todo_dependencies",
+        }
+
+
+def test_cyclic_handoff_returns_a_dependency_blocker() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "cyclic-handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {"system": "planner", "reference": "cycle"},
+                    "goal": {
+                        "id": "cyclic-goal",
+                        "title": "Cyclic planning handoff",
+                        "requirement": "Run two planned Todos unattended.",
+                        "acceptance": [
+                            {"id": "AC-1", "statement": "First behavior works."},
+                            {"id": "AC-2", "statement": "Second behavior works."},
+                        ],
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "First",
+                            "depends_on": ["T-2"],
+                            "acceptance_ids": ["AC-1"],
+                        },
+                        {
+                            "id": "T-2",
+                            "title": "Second",
+                            "depends_on": ["T-1"],
+                            "acceptance_ids": ["AC-2"],
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = GoalIntake().inspect(
+            repository=repository,
+            handoff_path=handoff,
+        )
+
+        assert result.readiness == "blocked"
+        assert result.next_action == "resolve_handoff_blockers"
+        assert {item.code for item in result.blockers} >= {
+            "todo_dependencies"
+        }
+
+
+def test_malformed_handoff_returns_an_actionable_validation_blocker() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "malformed-handoff.json"
+        handoff.write_text(
+            json.dumps({"unexpected": True}),
+            encoding="utf-8",
+        )
+
+        result = GoalIntake().inspect(
+            repository=repository,
+            handoff_path=handoff,
+        )
+
+        assert result.readiness == "blocked"
+        assert result.next_action == "resolve_handoff_blockers"
+        assert result.planning_handoff == {}
+        assert result.execution_envelope == {}
+        assert [item.code for item in result.blockers] == [
+            "handoff_validation"
+        ]
+        assert result.blockers[0].action == (
+            "Provide aiwb.planning-handoff schema_version 1 or a bare issue "
+            "JSON document with number, title, and body."
+        )
+
+
+def test_invalid_json_handoff_returns_an_actionable_validation_blocker() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "invalid.json"
+        handoff.write_text('{"schema_version": 1,', encoding="utf-8")
+
+        result = GoalIntake().inspect(
+            repository=repository,
+            handoff_path=handoff,
+        )
+
+        assert result.readiness == "blocked"
+        assert result.next_action == "resolve_handoff_blockers"
+        assert [item.code for item in result.blockers] == [
+            "handoff_validation"
+        ]
+        assert "cannot read planning handoff" in result.blockers[0].message
+
+
+def test_cli_mcp_and_skill_share_planning_handoff_intake_semantics() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {"system": "planner", "reference": "plan-14"},
+                    "goal": {
+                        "id": "goal-14",
+                        "title": "Accept a planning handoff",
+                        "requirement": "Run two planned Todos unattended.",
+                        "acceptance": [
+                            {"id": "AC-1", "statement": "First behavior works."},
+                            {"id": "AC-2", "statement": "Second behavior works."},
+                        ],
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "First behavior",
+                            "depends_on": [],
+                            "acceptance_ids": ["AC-1"],
+                        },
+                        {
+                            "id": "T-2",
+                            "title": "Second behavior",
+                            "depends_on": ["T-1"],
+                            "acceptance_ids": ["AC-2"],
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        expected = GoalIntake().inspect(
+            repository=repository,
+            handoff_path=handoff,
+        ).to_dict()
+        environment = os.environ.copy()
+        environment["PYTHONPATH"] = str(TOOL_ROOT / "src")
+        missing_socket = root / "missing-daemon.sock"
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "aiwb",
+                "goal",
+                "intake",
+                "--repo",
+                str(repository),
+                "--handoff",
+                str(handoff),
+                "--socket",
+                str(missing_socket),
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environment,
+        )
+        cli_value = json.loads(completed.stdout)
+
+        result = McpServer(missing_socket)._call_tool(
+            "aiwb_goal_intake",
+            {
+                "repository": str(repository),
+                "handoff_path": str(handoff),
+            },
+        )
+        assert result["isError"] is False
+        mcp_value = json.loads(result["content"][0]["text"])
+
+        skill_text = (
+            TOOL_ROOT / "skills" / "intake-aiwb-goal" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        assert cli_value == expected
+        assert mcp_value == expected
+        assert "--handoff" in skill_text
+        assert "handoff_path" in skill_text
+        assert "reimplement" in skill_text
+
+
 def test_cli_and_mcp_share_the_same_intake_result() -> None:
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)

--- a/tools/agent-orchestrator/tests/test_preflight.py
+++ b/tools/agent-orchestrator/tests/test_preflight.py
@@ -15,8 +15,13 @@ import pytest
 TOOL_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(TOOL_ROOT / "src"))
 
-from aiwb import ContractError, preview_execution  # noqa: E402
+from aiwb import AgentRequest, ContractError, GoalRunner, preview_execution  # noqa: E402
 from aiwb.mcp_server import McpServer  # noqa: E402
+
+
+class FailIfCalledAgent:
+    def run(self, request: AgentRequest):
+        raise AssertionError(f"Agent must not start during preflight: {request.role}")
 
 
 def test_draft_contract_preflight_is_side_effect_free_and_counts_the_dag() -> None:
@@ -148,7 +153,7 @@ def test_approved_contract_uses_the_same_preflight_baseline() -> None:
         assert envelope.to_dict()["deterministic"]["harness_executions"] == 10
 
 
-def test_preflight_rejects_a_production_target_through_project_policy() -> None:
+def test_repo_local_preflight_reports_a_production_target_blocker() -> None:
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
         repository = _create_repository(root)
@@ -166,8 +171,518 @@ def test_preflight_rejects_a_production_target_through_project_policy() -> None:
             encoding="utf-8",
         )
 
-        with pytest.raises(ContractError, match="production Harness profile is forbidden"):
-            preview_execution(contract)
+        result = preview_execution(contract).to_dict()
+
+        assert result["readiness"] == "blocked"
+        assert result["blockers"] == [
+            {
+                "code": "production_target",
+                "message": "production Harness profile is forbidden: production",
+                "action": (
+                    f"Review {workflow.resolve()} and use only local or "
+                    "non-production Harness and image profiles."
+                ),
+            }
+        ]
+
+
+def test_preflight_accepts_an_explicit_approved_policy_outside_the_repository() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        local_workflow = repository / ".ai-workbench" / "workflow.yaml"
+        external_policy = root / "reviewed-policy.yaml"
+        external_policy.write_bytes(local_workflow.read_bytes())
+        local_workflow.unlink()
+        local_workflow.parent.rmdir()
+        contract = _write_draft_contract(root, repository)
+        before = _tree(repository)
+
+        envelope = preview_execution(contract, workflow_path=external_policy)
+
+        assert _tree(repository) == before
+        assert not local_workflow.exists()
+        assert envelope.approval_status == "draft"
+        assert envelope.layers == (("T-1", "T-2"),)
+        assert envelope.to_dict()["policy"] == {
+            "path": str(external_policy.resolve()),
+            "source": "explicit",
+            "candidate_commands": [],
+            "approved_commands": [
+                [sys.executable, "-m", "pytest", "-q"],
+            ],
+        }
+
+
+def test_cli_and_mcp_accept_equivalent_explicit_policy_paths() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        contract = _write_draft_contract(root, repository)
+        external_policy = root / "reviewed-policy.yaml"
+        external_policy.write_bytes(
+            (repository / ".ai-workbench" / "workflow.yaml").read_bytes()
+        )
+        expected = preview_execution(
+            contract,
+            workflow_path=external_policy,
+        ).to_dict()
+        environment = os.environ.copy()
+        environment["PYTHONPATH"] = str(TOOL_ROOT / "src")
+
+        cli_values = []
+        for option in ("--workflow", "--policy"):
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "aiwb",
+                    "goal",
+                    "preflight",
+                    "--contract",
+                    str(contract),
+                    option,
+                    str(external_policy),
+                ],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=environment,
+            )
+            cli_values.append(json.loads(completed.stdout))
+
+        server = McpServer(root / "missing-daemon.sock")
+        mcp_values = []
+        for argument in ("workflow_path", "policy_path"):
+            result = server._call_tool(
+                "aiwb_goal_preflight",
+                {
+                    "contract_path": str(contract),
+                    argument: str(external_policy),
+                },
+            )
+            assert result["isError"] is False
+            mcp_values.append(json.loads(result["content"][0]["text"]))
+
+        assert cli_values == [expected, expected]
+        assert mcp_values == [expected, expected]
+
+
+def test_preflight_reports_candidate_and_approved_commands_separately() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        contract = _write_draft_contract(root, repository)
+        external_policy = root / "reviewed-policy.yaml"
+        policy = yaml.safe_load(
+            (repository / ".ai-workbench" / "workflow.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        policy["suggestions"] = {
+            "commands": {
+                "focused": {
+                    "argv": [sys.executable, "-m", "pytest", "tests/test_focused.py"],
+                    "reason": "focused test discovered",
+                }
+            }
+        }
+        external_policy.write_text(
+            yaml.safe_dump(policy, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        result = preview_execution(
+            contract,
+            workflow_path=external_policy,
+        ).to_dict()
+
+        assert result["policy"]["candidate_commands"] == [
+            {
+                "name": "focused",
+                "argv": [
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "tests/test_focused.py",
+                ],
+                "reason": "focused test discovered",
+            }
+        ]
+        assert result["policy"]["approved_commands"] == [
+            [sys.executable, "-m", "pytest", "-q"],
+        ]
+
+
+def test_candidate_command_requires_an_exact_approved_mapping() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        contract = _write_draft_contract(root, repository)
+        contract_data = yaml.safe_load(contract.read_text(encoding="utf-8"))
+        candidate_command = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/test_focused.py",
+        ]
+        for todo in contract_data["todos"]:
+            todo["test"]["command"] = candidate_command
+        contract.write_text(
+            yaml.safe_dump(contract_data, sort_keys=False),
+            encoding="utf-8",
+        )
+        external_policy = root / "reviewed-policy.yaml"
+        policy = yaml.safe_load(
+            (repository / ".ai-workbench" / "workflow.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        policy["suggestions"] = {
+            "commands": {
+                "focused": {
+                    "argv": candidate_command,
+                    "reason": "focused test discovered",
+                }
+            }
+        }
+        external_policy.write_text(
+            yaml.safe_dump(policy, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        result = preview_execution(
+            contract,
+            workflow_path=external_policy,
+        ).to_dict()
+
+        assert result["readiness"] == "blocked"
+        assert result["policy"]["candidate_commands"][0]["argv"] == candidate_command
+        assert result["policy"]["approved_commands"] == [
+            [sys.executable, "-m", "pytest", "-q"],
+        ]
+        assert result["blockers"] == [
+            {
+                "code": "approved_command_missing",
+                "message": (
+                    "Contract Todo T-1 test command is not exactly approved by "
+                    "the selected policy."
+                ),
+                "action": (
+                    "Review and add the exact command to "
+                    f"{external_policy.resolve()} capabilities.commands with "
+                    "approved: true."
+                ),
+            },
+            {
+                "code": "approved_command_missing",
+                "message": (
+                    "Contract Todo T-2 test command is not exactly approved by "
+                    "the selected policy."
+                ),
+                "action": (
+                    "Review and add the exact command to "
+                    f"{external_policy.resolve()} capabilities.commands with "
+                    "approved: true."
+                ),
+            },
+        ]
+
+
+def test_explicit_policy_root_mismatch_is_an_actionable_blocker() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        other_repository = root / "other-project"
+        other_repository.mkdir()
+        contract = _write_draft_contract(root, repository)
+        external_policy = root / "wrong-root-policy.yaml"
+        policy = yaml.safe_load(
+            (repository / ".ai-workbench" / "workflow.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        policy["project"]["root"] = str(other_repository)
+        external_policy.write_text(
+            yaml.safe_dump(policy, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        result = preview_execution(
+            contract,
+            workflow_path=external_policy,
+        ).to_dict()
+
+        assert result["readiness"] == "blocked"
+        assert result["blockers"] == [
+            {
+                "code": "policy_root_mismatch",
+                "message": (
+                    "The selected policy root does not match the Contract repository."
+                ),
+                "action": (
+                    f"Review {external_policy.resolve()} and set project.root to "
+                    f"{repository.resolve()}."
+                ),
+            }
+        ]
+
+
+def test_explicit_policy_production_target_is_an_actionable_blocker() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        contract = _write_draft_contract(root, repository)
+        external_policy = root / "production-policy.yaml"
+        policy = yaml.safe_load(
+            (repository / ".ai-workbench" / "workflow.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        policy["harness"]["profiles"]["production"] = {
+            "kind": "local_process",
+            "environment": "production",
+            "start": {"command": [sys.executable, "-m", "http.server"]},
+            "ready": {"url": "http://127.0.0.1:8000", "timeout_seconds": 5},
+        }
+        external_policy.write_text(
+            yaml.safe_dump(policy, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        result = preview_execution(
+            contract,
+            workflow_path=external_policy,
+        ).to_dict()
+
+        assert result["readiness"] == "blocked"
+        assert result["blockers"] == [
+            {
+                "code": "production_target",
+                "message": "production Harness profile is forbidden: production",
+                "action": (
+                    f"Review {external_policy.resolve()} and use only local or "
+                    "non-production Harness and image profiles."
+                ),
+            }
+        ]
+
+
+def test_explicit_policy_production_image_is_an_actionable_blocker() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        contract = _write_draft_contract(root, repository)
+        external_policy = root / "production-image-policy.yaml"
+        policy = yaml.safe_load(
+            (repository / ".ai-workbench" / "workflow.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        image_command = [sys.executable, "image-builder.py"]
+        policy["capabilities"]["commands"]["image"] = {
+            "argv": image_command,
+            "approved": True,
+        }
+        policy["images"] = {
+            "profiles": {
+                "production": {
+                    "environment": "production",
+                    "start": {"command": image_command},
+                    "status": {"command": image_command},
+                    "result": {"command": image_command},
+                }
+            }
+        }
+        external_policy.write_text(
+            yaml.safe_dump(policy, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        result = preview_execution(
+            contract,
+            workflow_path=external_policy,
+        ).to_dict()
+
+        assert result["readiness"] == "blocked"
+        assert result["blockers"] == [
+            {
+                "code": "production_target",
+                "message": "production image profile is forbidden: production",
+                "action": (
+                    f"Review {external_policy.resolve()} and use only local or "
+                    "non-production Harness and image profiles."
+                ),
+            }
+        ]
+
+
+def test_explicit_policy_requires_reviewed_approval_state() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        contract = _write_draft_contract(root, repository)
+        external_policy = root / "draft-policy.yaml"
+        policy = yaml.safe_load(
+            (repository / ".ai-workbench" / "workflow.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        policy["status"] = "draft"
+        external_policy.write_text(
+            yaml.safe_dump(policy, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        result = preview_execution(
+            contract,
+            workflow_path=external_policy,
+        ).to_dict()
+
+        assert result["readiness"] == "blocked"
+        assert result["blockers"] == [
+            {
+                "code": "policy_not_approved",
+                "message": "project policy status must be approved",
+                "action": (
+                    f"Review {external_policy.resolve()}, explicitly approve its "
+                    "trusted project and capabilities, then rerun preflight."
+                ),
+            }
+        ]
+
+
+def test_policy_with_only_candidate_commands_stays_unapproved() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        contract = _write_draft_contract(root, repository)
+        external_policy = root / "candidate-only-policy.yaml"
+        policy = yaml.safe_load(
+            (repository / ".ai-workbench" / "workflow.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        command = [sys.executable, "-m", "pytest", "-q"]
+        policy["suggestions"] = {
+            "commands": {
+                "unit": {
+                    "argv": command,
+                    "reason": "pytest configuration detected",
+                }
+            }
+        }
+        policy["capabilities"]["commands"] = {}
+        external_policy.write_text(
+            yaml.safe_dump(policy, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        result = preview_execution(
+            contract,
+            workflow_path=external_policy,
+        ).to_dict()
+
+        assert result["readiness"] == "blocked"
+        assert result["policy"]["candidate_commands"] == [
+            {
+                "name": "unit",
+                "argv": command,
+                "reason": "pytest configuration detected",
+            }
+        ]
+        assert result["policy"]["approved_commands"] == []
+        assert result["blockers"] == [
+            {
+                "code": "approved_command_missing",
+                "message": "project policy requires an approved command",
+                "action": (
+                    "Review and add the exact Contract test command to "
+                    f"{external_policy.resolve()} capabilities.commands with "
+                    "approved: true."
+                ),
+            }
+        ]
+
+
+def test_policy_command_with_approval_false_stays_unapproved() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        contract = _write_draft_contract(root, repository)
+        external_policy = root / "unapproved-command-policy.yaml"
+        policy = yaml.safe_load(
+            (repository / ".ai-workbench" / "workflow.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        policy["capabilities"]["commands"]["unit"]["approved"] = False
+        external_policy.write_text(
+            yaml.safe_dump(policy, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        result = preview_execution(
+            contract,
+            workflow_path=external_policy,
+        ).to_dict()
+
+        assert result["readiness"] == "blocked"
+        assert result["policy"]["approved_commands"] == []
+        assert result["blockers"] == [
+            {
+                "code": "approved_command_missing",
+                "message": "project command 'unit' must be approved",
+                "action": (
+                    "Review and add the exact Contract test command to "
+                    f"{external_policy.resolve()} capabilities.commands with "
+                    "approved: true."
+                ),
+            }
+        ]
+
+
+def test_candidate_only_policy_remains_rejected_by_strict_execution() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        contract = _write_draft_contract(root, repository)
+        contract_data = yaml.safe_load(contract.read_text(encoding="utf-8"))
+        contract_data["approval"] = {
+            "status": "approved",
+            "approved_by": "owner",
+            "approved_at": datetime(2026, 7, 27, tzinfo=timezone.utc),
+        }
+        contract.write_text(
+            yaml.safe_dump(contract_data, sort_keys=False),
+            encoding="utf-8",
+        )
+        workflow = repository / ".ai-workbench" / "workflow.yaml"
+        policy = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+        command = [sys.executable, "-m", "pytest", "-q"]
+        policy["suggestions"] = {
+            "commands": {
+                "unit": {
+                    "argv": command,
+                    "reason": "pytest configuration detected",
+                }
+            }
+        }
+        policy["capabilities"]["commands"] = {}
+        workflow.write_text(
+            yaml.safe_dump(policy, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(
+            ContractError,
+            match="project policy requires an approved command",
+        ):
+            GoalRunner(
+                state_dir=root / "state",
+                agent=FailIfCalledAgent(),
+            ).prepare(contract)
 
 
 def _create_repository(root: Path) -> Path:

--- a/tools/agent-orchestrator/tests/test_project_policy.py
+++ b/tools/agent-orchestrator/tests/test_project_policy.py
@@ -181,6 +181,46 @@ def test_project_policy_loads_explicit_local_role_skills() -> None:
         }
 
 
+def test_malformed_candidate_command_does_not_block_approved_policy() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "project"
+        repository.mkdir()
+        command = [sys.executable, "-m", "pytest", "-q"]
+        workflow = repository / ".ai-workbench" / "workflow.yaml"
+        workflow.parent.mkdir()
+        workflow.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "status": "approved",
+                    "project": {"root": str(repository), "trusted": True},
+                    "suggestions": {
+                        "commands": {
+                            "malformed": {
+                                "argv": "pytest -q",
+                                "reason": ["not", "a", "string"],
+                            }
+                        }
+                    },
+                    "capabilities": {
+                        "commands": {
+                            "unit": {"argv": command, "approved": True},
+                        },
+                        "skills": {},
+                    },
+                    "harness": {"profiles": {}},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        policy = ProjectPolicy.load(workflow)
+
+        assert policy.candidate_commands == ()
+        assert policy.approved_commands == (tuple(command),)
+
+
 @pytest.mark.parametrize(
     ("skills", "message"),
     [


### PR DESCRIPTION
## Summary
- Add read-only planning handoff intake for versioned handoff JSON, GitHub REST issue JSON, and gh issue JSON.
- Add explicit preflight policy paths via CLI/MCP while separating candidate commands from approved commands.
- Add structured blockers for unsupported/malformed handoffs, missing command approval, root mismatch, unapproved policy, and production targets.
- Add a test extra so the agent orchestrator test suite installs pytest via `pip install -e '.[test]'`.

## Test Plan
- `PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m pytest -q` -> 131 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m compileall -q tools/agent-orchestrator/src tools/agent-orchestrator/tests`
- `git diff --check`
- `diff -q .codex/skills/intake-aiwb-goal/SKILL.md tools/agent-orchestrator/skills/intake-aiwb-goal/SKILL.md`