### PR TITLE
refactor: introduce HarnessSetup lifecycle seam

### DIFF
--- a/tools/agent-orchestrator/README.md
+++ b/tools/agent-orchestrator/README.md
@@ -14,6 +14,17 @@ The public tool contains no organization-specific integrations. Projects expose 
 
 ## Module Shape
 
+`HarnessSetup.inspect/plan/apply/verify` is the project setup lifecycle interface
+and test surface. It owns structured assessment, Plan, Candidate, and
+Verification results while adapting the existing repository discovery,
+initialization, Skill setup, project policy, and doctor behavior. Read-only
+inspection and planning do not execute project commands or write configuration;
+Apply still requires explicit confirmation.
+
+This interface is currently a compatibility prefactor. Recipe selection,
+dynamic probes, candidate worktrees, and pipeline verification remain later
+delivery slices rather than hidden behavior in setup callers.
+
 `GoalRunner.run(contract)` is the execution interface and test surface. It hides Contract validation, checkpoint persistence, Git worktree management, RED/GREEN machine gates, role prompts, Evidence capture, and recovery.
 
 `DaemonClient.submit/status/report/evidence` is the control interface. It hides the Unix socket protocol, background queue, SQLite job state, thread pool, stale socket handling, content-addressed Evidence retrieval, and process-restart recovery.

--- a/tools/agent-orchestrator/src/aiwb/__init__.py
+++ b/tools/agent-orchestrator/src/aiwb/__init__.py
@@ -31,6 +31,16 @@ from .harness import (
     HarnessRequest,
     LocalProcessHarness,
 )
+from .harness_setup import (
+    HarnessApplyRequest,
+    HarnessAssessment,
+    HarnessCandidate,
+    HarnessPlan,
+    HarnessSetup,
+    HarnessSetupRequest,
+    HarnessVerification,
+    HarnessVerifyRequest,
+)
 from .image import ImageBuildError
 from .intake import GoalIntake, GoalIntakeResult, IntakeBlocker
 from .kubernetes import JanitorReport, KubernetesHarness, KubernetesJanitor
@@ -108,8 +118,16 @@ __all__ = [
     "GateError",
     "HarnessError",
     "HarnessExecution",
+    "HarnessApplyRequest",
+    "HarnessAssessment",
+    "HarnessCandidate",
+    "HarnessPlan",
     "HarnessProfile",
     "HarnessRequest",
+    "HarnessSetup",
+    "HarnessSetupRequest",
+    "HarnessVerification",
+    "HarnessVerifyRequest",
     "ImageBuildError",
     "IntakeBlocker",
     "KubernetesHarness",

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -8,16 +8,19 @@ from typing import Optional, Sequence, Tuple
 
 from .agent import AgentRouter, ClaudeCodeCliAdapter, CodexCliAdapter
 from .daemon import AgentDaemon, DaemonClient, DaemonError
+from .harness_setup import (
+    HarnessApplyRequest,
+    HarnessSetup,
+    HarnessSetupRequest,
+    HarnessVerifyRequest,
+)
 from .intake import GoalIntake
 from .kubernetes import KubernetesJanitor
 from .project import (
     ProjectConfigError,
-    ProjectDoctor,
     ProjectInitError,
-    ProjectInitializer,
 )
 from .runner import GoalRunner, preview_execution
-from .setup import WorkbenchSetup
 from .skills import SkillCatalog
 from .supervisor import LaunchdError, LaunchdService
 from .tickets import TicketContractDraftBuilder
@@ -210,30 +213,53 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _run_init(options: argparse.Namespace) -> int:
-    result = ProjectInitializer().initialize(
-        repository=options.repo,
-        output_path=options.output,
-        force=options.force,
+    setup = HarnessSetup()
+    plan = setup.plan(
+        HarnessSetupRequest(
+            repository=options.repo,
+            operation="initialize",
+            output_path=options.output,
+        )
     )
-    _print_json(result.__dict__)
+    result = setup.apply(
+        HarnessApplyRequest(
+            plan=plan,
+            confirmed=True,
+            force=options.force,
+        )
+    )
+    _print_json(
+        {
+            "config": result.workflow_path,
+            "status": result.status,
+            "suggestions": result.suggestions,
+        }
+    )
     return 0
 
 
 def _run_setup(options: argparse.Namespace) -> int:
-    setup = WorkbenchSetup()
+    setup = HarnessSetup()
     targets = tuple(options.agent_target)
+    plan = setup.plan(
+        HarnessSetupRequest(
+            repository=options.repo,
+            agent_targets=targets,
+        )
+    )
     role_skills = _role_skills(options.role_skill)
     pack_skills = _pack_skills(options.install_pack, options.pack_skill)
     pack_profiles = _pack_profiles(options.install_pack, options.pack_profile)
     if options.apply:
         result = setup.apply(
-            repository=options.repo,
-            confirmed=True,
-            agent_targets=targets,
-            role_skills=role_skills,
-            install_skills=tuple(options.install_skill),
-            pack_skills=pack_skills,
-            pack_profiles=pack_profiles,
+            HarnessApplyRequest(
+                plan=plan,
+                confirmed=True,
+                role_skills=role_skills,
+                install_skills=tuple(options.install_skill),
+                pack_skills=pack_skills,
+                pack_profiles=pack_profiles,
+            )
         )
         _print_json(
             {
@@ -246,7 +272,7 @@ def _run_setup(options: argparse.Namespace) -> int:
             }
         )
     else:
-        result = setup.inspect(options.repo, targets)
+        result = plan.assessment
         _print_json(
             {
                 "workflow_path": result.workflow_path,
@@ -272,12 +298,15 @@ def _run_skills(options: argparse.Namespace) -> int:
 
 
 def _run_doctor(options: argparse.Namespace) -> int:
-    report = ProjectDoctor().inspect(
-        config_path=options.config,
-        codex_bin=options.codex_bin,
-        agent_provider=options.agent_provider,
-        claude_bin=options.claude_bin,
+    result = HarnessSetup().verify(
+        HarnessVerifyRequest(
+            config_path=options.config,
+            codex_bin=options.codex_bin,
+            agent_provider=options.agent_provider,
+            claude_bin=options.claude_bin,
+        )
     )
+    report = result.report
     _print_json(report.to_dict())
     return 0 if report.status == "ok" else 1
 

--- a/tools/agent-orchestrator/src/aiwb/harness_setup.py
+++ b/tools/agent-orchestrator/src/aiwb/harness_setup.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Optional, Sequence, Tuple
+
+import yaml
+
+from .project import DoctorReport, ProjectDoctor, ProjectInitializer
+from .skills import (
+    SkillCatalog,
+    SkillCatalogSnapshot,
+    SkillPackCatalog,
+    SkillPackDescriptor,
+)
+
+
+@dataclass(frozen=True)
+class HarnessSetupRequest:
+    repository: Path
+    agent_targets: Tuple[str, ...] = ()
+    operation: str = "setup"
+    output_path: Optional[Path] = None
+
+
+@dataclass(frozen=True)
+class HarnessAssessment:
+    state: str
+    repository: str
+    workflow_action: str
+    workflow_path: str
+    suggestions: int
+    agent_targets: Tuple[str, ...]
+    catalog: SkillCatalogSnapshot
+    packs: Tuple[SkillPackDescriptor, ...]
+
+
+@dataclass(frozen=True)
+class HarnessPlan:
+    state: str
+    request: HarnessSetupRequest
+    assessment: HarnessAssessment
+
+
+@dataclass(frozen=True)
+class HarnessApplyRequest:
+    plan: HarnessPlan
+    confirmed: bool
+    force: bool = False
+    role_skills: Optional[Mapping[str, Sequence[str]]] = None
+    install_skills: Tuple[str, ...] = ()
+    pack_skills: Optional[Mapping[str, Sequence[str]]] = None
+    pack_profiles: Optional[Mapping[str, Sequence[str]]] = None
+
+
+@dataclass(frozen=True)
+class HarnessCandidate:
+    state: str
+    workflow_path: str
+    workflow_action: str
+    changed: bool
+    agent_targets: Tuple[str, ...]
+    installed_packs: Tuple[str, ...] = ()
+    next_actions: Tuple[str, ...] = ()
+    status: str = ""
+    suggestions: int = 0
+
+
+@dataclass(frozen=True)
+class HarnessVerifyRequest:
+    config_path: Path
+    codex_bin: str = "codex"
+    agent_provider: str = "codex"
+    claude_bin: str = "claude"
+
+
+@dataclass(frozen=True)
+class HarnessVerification:
+    state: str
+    config_path: str
+    report: DoctorReport
+
+
+class HarnessSetup:
+    """Own the project Harness setup lifecycle behind one public seam."""
+
+    def __init__(
+        self,
+        catalog: Optional[SkillCatalog] = None,
+        pack_catalog: Optional[SkillPackCatalog] = None,
+        command_runner: Optional[Callable[[Tuple[str, ...], Path], None]] = None,
+    ) -> None:
+        self._catalog = catalog or SkillCatalog()
+        self._pack_catalog = pack_catalog or SkillPackCatalog()
+        self._command_runner = command_runner or _run_pack_command
+        self._initializer = ProjectInitializer()
+
+    def inspect(self, request: HarnessSetupRequest) -> HarnessAssessment:
+        if request.operation not in {"setup", "initialize"}:
+            raise ValueError("Harness setup operation must be setup or initialize")
+        if any(
+            target not in {"codex", "claude-code"}
+            for target in request.agent_targets
+        ):
+            raise ValueError("agent targets must be codex or claude-code")
+        repository = Path(request.repository).expanduser().resolve()
+        preview = self._initializer.preview(repository, request.output_path)
+        return HarnessAssessment(
+            state="assessed",
+            repository=str(repository),
+            workflow_action=(
+                "inspect_existing"
+                if Path(preview.config).exists()
+                else "create_draft"
+            ),
+            workflow_path=preview.config,
+            suggestions=preview.suggestions,
+            agent_targets=request.agent_targets,
+            catalog=self._catalog.inspect(repository),
+            packs=self._pack_catalog.inspect(),
+        )
+
+    def plan(self, request: HarnessSetupRequest) -> HarnessPlan:
+        return HarnessPlan(
+            state="planned",
+            request=request,
+            assessment=self.inspect(request),
+        )
+
+    def apply(self, request: HarnessApplyRequest) -> HarnessCandidate:
+        if request.plan.state != "planned":
+            raise ValueError("apply requires a planned Harness Plan")
+        if not request.confirmed:
+            raise ValueError("setup requires explicit confirmation before writing")
+        plan = request.plan
+        assessment = plan.assessment
+        if assessment.state != "assessed":
+            raise ValueError("apply requires an assessed Harness Plan")
+        repository = Path(plan.request.repository).expanduser().resolve()
+        if assessment.repository != str(repository):
+            raise ValueError("Harness Plan repository does not match its request")
+        if assessment != self.inspect(plan.request):
+            raise ValueError("Harness Plan assessment is stale or has been modified")
+        if plan.request.operation == "initialize":
+            initialized = self._initializer.initialize(
+                repository=repository,
+                output_path=plan.request.output_path,
+                force=request.force,
+            )
+            return HarnessCandidate(
+                state="candidate",
+                workflow_path=initialized.config,
+                workflow_action=(
+                    "replaced"
+                    if assessment.workflow_action == "inspect_existing"
+                    else "created"
+                ),
+                changed=True,
+                agent_targets=plan.request.agent_targets,
+                status=initialized.status,
+                suggestions=initialized.suggestions,
+            )
+
+        selected_packs = request.pack_skills or {}
+        selected_profiles = request.pack_profiles or {}
+        if (
+            request.install_skills or selected_packs or selected_profiles
+        ) and not plan.request.agent_targets:
+            raise ValueError("installing a Skill requires an explicit agent target")
+        pack_plans = self._pack_catalog.plans(
+            selected_packs,
+            plan.request.agent_targets,
+            profiles=selected_profiles,
+        )
+        workflow = Path(assessment.workflow_path)
+        created = not workflow.exists()
+        if created:
+            self._initializer.initialize(repository)
+        document = _workflow_document(workflow)
+        changed = created
+        workflow_changed = created
+        known_local_paths = {
+            skill.path for skill in assessment.catalog.skills if skill.source == "project"
+        }
+        selected = request.role_skills or {}
+        capabilities = document.setdefault("capabilities", {})
+        if not isinstance(capabilities, dict):
+            raise ValueError("workflow capabilities must be a mapping")
+        configured_skills = capabilities.setdefault("skills", {})
+        if not isinstance(configured_skills, dict):
+            raise ValueError("workflow capabilities.skills must be a mapping")
+        for role, paths in selected.items():
+            if role not in _ROLE_NAMES:
+                raise ValueError(f"unsupported role: {role}")
+            paths = tuple(paths)
+            if not paths or any(path not in known_local_paths for path in paths):
+                raise ValueError(
+                    f"role skills must be discovered project-local Skills: {role}"
+                )
+            configured = configured_skills.setdefault(role, [])
+            if not isinstance(configured, list):
+                raise ValueError(
+                    f"workflow capabilities.skills.{role} must be a list"
+                )
+            for path in paths:
+                if path not in configured:
+                    configured.append(path)
+                    changed = True
+                    workflow_changed = True
+        for target in plan.request.agent_targets:
+            target_root = repository / _TARGET_SKILL_ROOTS[target]
+            _require_within_repository(target_root.parent, repository)
+            for name in request.install_skills:
+                source = self._catalog.bundled_source(name)
+                destination = target_root / name / "SKILL.md"
+                _require_within_repository(destination.parent, repository)
+                if destination.is_symlink():
+                    raise ValueError(
+                        "Skill destination must remain inside the repository"
+                    )
+                source_bytes = source.read_bytes()
+                if destination.is_file() and destination.read_bytes() == source_bytes:
+                    continue
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                _require_within_repository(destination.parent, repository)
+                destination.write_bytes(source_bytes)
+                changed = True
+        for pack_plan in pack_plans:
+            self._command_runner(pack_plan.command, repository)
+            changed = True
+        if workflow_changed:
+            workflow.write_text(
+                yaml.safe_dump(document, sort_keys=False),
+                encoding="utf-8",
+            )
+        return HarnessCandidate(
+            state="candidate",
+            workflow_path=str(workflow),
+            workflow_action=(
+                "created" if created else "updated" if changed else "unchanged"
+            ),
+            changed=changed,
+            agent_targets=plan.request.agent_targets,
+            installed_packs=tuple(
+                dict.fromkeys(pack_plan.name for pack_plan in pack_plans)
+            ),
+            next_actions=tuple(
+                dict.fromkeys(
+                    pack_plan.setup_action
+                    for pack_plan in pack_plans
+                    if pack_plan.setup_action
+                )
+            ),
+        )
+
+    def verify(self, request: HarnessVerifyRequest) -> HarnessVerification:
+        config_path = Path(request.config_path).expanduser().resolve()
+        report = ProjectDoctor().inspect(
+            config_path=config_path,
+            codex_bin=request.codex_bin,
+            agent_provider=request.agent_provider,
+            claude_bin=request.claude_bin,
+        )
+        return HarnessVerification(
+            state="verified" if report.status == "ok" else "verification_failed",
+            config_path=str(config_path),
+            report=report,
+        )
+
+
+_ROLE_NAMES = frozenset(
+    {"test_designer", "implementer", "verifier", "conflict_repairer"}
+)
+_TARGET_SKILL_ROOTS = {
+    "codex": ".codex/skills",
+    "claude-code": ".claude/skills",
+}
+
+
+def _workflow_document(path: Path) -> dict[str, object]:
+    try:
+        document = yaml.safe_load(path.read_bytes())
+    except (OSError, yaml.YAMLError) as error:
+        raise ValueError(f"cannot read workflow: {error}") from error
+    if not isinstance(document, dict):
+        raise ValueError("workflow must be a mapping")
+    return document
+
+
+def _require_within_repository(path: Path, repository: Path) -> None:
+    try:
+        path.resolve().relative_to(repository)
+    except ValueError as error:
+        raise ValueError("Skill destination must remain inside the repository") from error
+
+
+def _run_pack_command(command: Tuple[str, ...], repository: Path) -> None:
+    try:
+        subprocess.run(
+            command,
+            cwd=str(repository),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ValueError(f"Skill pack installation failed: {error}") from error

--- a/tools/agent-orchestrator/src/aiwb/setup.py
+++ b/tools/agent-orchestrator/src/aiwb/setup.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Mapping, Optional, Sequence, Tuple
 
-import yaml
-
-from .project import ProjectInitializer
+from .harness_setup import (
+    HarnessApplyRequest,
+    HarnessSetup,
+    HarnessSetupRequest,
+)
 from .skills import (
     SkillCatalog,
     SkillCatalogSnapshot,
@@ -45,30 +46,30 @@ class WorkbenchSetup:
         pack_catalog: Optional[SkillPackCatalog] = None,
         command_runner: Optional[Callable[[Tuple[str, ...], Path], None]] = None,
     ) -> None:
-        self._catalog = catalog or SkillCatalog()
-        self._pack_catalog = pack_catalog or SkillPackCatalog()
-        self._command_runner = command_runner or _run_pack_command
-        self._initializer = ProjectInitializer()
+        self._setup = HarnessSetup(
+            catalog=catalog,
+            pack_catalog=pack_catalog,
+            command_runner=command_runner,
+        )
 
     def inspect(
         self,
         repository: Path,
         agent_targets: Tuple[str, ...] = (),
     ) -> SetupInspection:
-        if any(target not in {"codex", "claude-code"} for target in agent_targets):
-            raise ValueError("agent targets must be codex or claude-code")
-        preview = self._initializer.preview(repository)
+        assessment = self._setup.inspect(
+            HarnessSetupRequest(
+                repository=repository,
+                agent_targets=agent_targets,
+            )
+        )
         return SetupInspection(
-            workflow_action=(
-                "inspect_existing"
-                if Path(preview.config).exists()
-                else "create_draft"
-            ),
-            workflow_path=preview.config,
-            suggestions=preview.suggestions,
-            agent_targets=agent_targets,
-            catalog=self._catalog.inspect(repository),
-            packs=self._pack_catalog.inspect(),
+            workflow_action=assessment.workflow_action,
+            workflow_path=assessment.workflow_path,
+            suggestions=assessment.suggestions,
+            agent_targets=assessment.agent_targets,
+            catalog=assessment.catalog,
+            packs=assessment.packs,
         )
 
     def apply(
@@ -81,124 +82,27 @@ class WorkbenchSetup:
         pack_skills: Optional[Mapping[str, Sequence[str]]] = None,
         pack_profiles: Optional[Mapping[str, Sequence[str]]] = None,
     ) -> SetupApplyResult:
-        if not confirmed:
-            raise ValueError("setup requires explicit confirmation before writing")
-        inspection = self.inspect(repository, agent_targets)
-        repository = Path(repository).expanduser().resolve()
-        selected_packs = pack_skills or {}
-        selected_profiles = pack_profiles or {}
-        if (install_skills or selected_packs or selected_profiles) and not agent_targets:
-            raise ValueError("installing a Skill requires an explicit agent target")
-        pack_plans = self._pack_catalog.plans(
-            selected_packs,
-            agent_targets,
-            profiles=selected_profiles,
-        )
-        workflow = Path(inspection.workflow_path)
-        created = not workflow.exists()
-        if created:
-            self._initializer.initialize(repository)
-        document = _workflow_document(workflow)
-        changed = created
-        workflow_changed = created
-        known_local_paths = {
-            skill.path for skill in inspection.catalog.skills if skill.source == "project"
-        }
-        selected = role_skills or {}
-        capabilities = document.setdefault("capabilities", {})
-        if not isinstance(capabilities, dict):
-            raise ValueError("workflow capabilities must be a mapping")
-        configured_skills = capabilities.setdefault("skills", {})
-        if not isinstance(configured_skills, dict):
-            raise ValueError("workflow capabilities.skills must be a mapping")
-        for role, paths in selected.items():
-            if role not in _ROLE_NAMES:
-                raise ValueError(f"unsupported role: {role}")
-            paths = tuple(paths)
-            if not paths or any(path not in known_local_paths for path in paths):
-                raise ValueError(f"role skills must be discovered project-local Skills: {role}")
-            configured = configured_skills.setdefault(role, [])
-            if not isinstance(configured, list):
-                raise ValueError(f"workflow capabilities.skills.{role} must be a list")
-            for path in paths:
-                if path not in configured:
-                    configured.append(path)
-                    changed = True
-                    workflow_changed = True
-        for target in agent_targets:
-            target_root = repository / _TARGET_SKILL_ROOTS[target]
-            _require_within_repository(target_root.parent, repository)
-            for name in install_skills:
-                source = self._catalog.bundled_source(name)
-                destination = target_root / name / "SKILL.md"
-                _require_within_repository(destination.parent, repository)
-                if destination.is_symlink():
-                    raise ValueError("Skill destination must remain inside the repository")
-                source_bytes = source.read_bytes()
-                if destination.is_file() and destination.read_bytes() == source_bytes:
-                    continue
-                destination.parent.mkdir(parents=True, exist_ok=True)
-                _require_within_repository(destination.parent, repository)
-                destination.write_bytes(source_bytes)
-                changed = True
-        for plan in pack_plans:
-            self._command_runner(plan.command, repository)
-            changed = True
-        if workflow_changed:
-            workflow.write_text(
-                yaml.safe_dump(document, sort_keys=False),
-                encoding="utf-8",
+        plan = self._setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                agent_targets=agent_targets,
             )
+        )
+        candidate = self._setup.apply(
+            HarnessApplyRequest(
+                plan=plan,
+                confirmed=confirmed,
+                role_skills=role_skills,
+                install_skills=install_skills,
+                pack_skills=pack_skills,
+                pack_profiles=pack_profiles,
+            )
+        )
         return SetupApplyResult(
-            workflow_path=str(workflow),
-            workflow_action=("created" if created else "updated" if changed else "unchanged"),
-            changed=changed,
-            agent_targets=agent_targets,
-            installed_packs=tuple(dict.fromkeys(plan.name for plan in pack_plans)),
-            next_actions=tuple(
-                dict.fromkeys(
-                    plan.setup_action for plan in pack_plans if plan.setup_action
-                )
-            ),
+            workflow_path=candidate.workflow_path,
+            workflow_action=candidate.workflow_action,
+            changed=candidate.changed,
+            agent_targets=candidate.agent_targets,
+            installed_packs=candidate.installed_packs,
+            next_actions=candidate.next_actions,
         )
-
-
-_ROLE_NAMES = frozenset(
-    {"test_designer", "implementer", "verifier", "conflict_repairer"}
-)
-_TARGET_SKILL_ROOTS = {
-    "codex": ".codex/skills",
-    "claude-code": ".claude/skills",
-}
-
-
-def _workflow_document(path: Path) -> dict[str, object]:
-    try:
-        document = yaml.safe_load(path.read_bytes())
-    except (OSError, yaml.YAMLError) as error:
-        raise ValueError(f"cannot read workflow: {error}") from error
-    if not isinstance(document, dict):
-        raise ValueError("workflow must be a mapping")
-    return document
-
-
-def _require_within_repository(path: Path, repository: Path) -> None:
-    try:
-        path.resolve().relative_to(repository)
-    except ValueError as error:
-        raise ValueError("Skill destination must remain inside the repository") from error
-
-
-def _run_pack_command(command: Tuple[str, ...], repository: Path) -> None:
-    try:
-        subprocess.run(
-            command,
-            cwd=str(repository),
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            timeout=120,
-        )
-    except (OSError, subprocess.SubprocessError) as error:
-        raise ValueError(f"Skill pack installation failed: {error}") from error

--- a/tools/agent-orchestrator/tests/test_harness_setup.py
+++ b/tools/agent-orchestrator/tests/test_harness_setup.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+import yaml
+
+TOOL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOL_ROOT / "src"))
+
+from aiwb import (  # noqa: E402
+    HarnessApplyRequest,
+    HarnessSetup,
+    HarnessSetupRequest,
+    HarnessVerifyRequest,
+    ProjectInitError,
+)
+
+
+def test_harness_setup_inspect_and_plan_are_read_only() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = root / "project"
+        marker = root / "script-was-executed"
+        (repository / "tests").mkdir(parents=True)
+        scripts = repository / "scripts"
+        scripts.mkdir()
+        script = scripts / "e2e-local.sh"
+        script.write_text(f"#!/bin/sh\ntouch '{marker}'\n", encoding="utf-8")
+        script.chmod(0o755)
+
+        setup = HarnessSetup()
+        request = HarnessSetupRequest(
+            repository=repository,
+            agent_targets=("codex",),
+        )
+
+        assessment = setup.inspect(request)
+        plan = setup.plan(request)
+
+        assert assessment.state == "assessed"
+        assert assessment.repository == str(repository.resolve())
+        assert assessment.workflow_action == "create_draft"
+        assert assessment.suggestions == 2
+        assert plan.state == "planned"
+        assert plan.assessment == assessment
+        assert plan.request == request
+        assert not marker.exists()
+        assert not (repository / ".ai-workbench" / "workflow.yaml").exists()
+
+
+def test_harness_setup_apply_requires_a_planned_explicitly_confirmed_request() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "project"
+        repository.mkdir()
+        setup = HarnessSetup()
+        plan = setup.plan(HarnessSetupRequest(repository=repository))
+
+        with pytest.raises(ValueError, match="planned Harness Plan"):
+            setup.apply(
+                HarnessApplyRequest(
+                    plan=replace(plan, state="draft"),
+                    confirmed=True,
+                )
+            )
+        with pytest.raises(ValueError, match="explicit confirmation"):
+            setup.apply(HarnessApplyRequest(plan=plan, confirmed=False))
+
+        candidate = setup.apply(HarnessApplyRequest(plan=plan, confirmed=True))
+
+        workflow = repository / ".ai-workbench" / "workflow.yaml"
+        assert candidate.state == "candidate"
+        assert candidate.workflow_path == str(workflow)
+        assert candidate.workflow_action == "created"
+        assert candidate.changed is True
+        assert workflow.is_file()
+
+
+def test_harness_setup_initialization_preserves_output_and_force_semantics() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "project"
+        repository.mkdir()
+        output = repository / "config" / "workflow.yaml"
+        setup = HarnessSetup()
+        request = HarnessSetupRequest(
+            repository=repository,
+            operation="initialize",
+            output_path=output,
+        )
+
+        plan = setup.plan(request)
+        candidate = setup.apply(
+            HarnessApplyRequest(plan=plan, confirmed=True)
+        )
+
+        assert plan.assessment.workflow_path == str(output.resolve())
+        assert candidate.state == "candidate"
+        assert candidate.status == "draft"
+        assert candidate.suggestions == 0
+        assert candidate.workflow_action == "created"
+        with pytest.raises(ValueError, match="stale"):
+            setup.apply(HarnessApplyRequest(plan=plan, confirmed=True))
+
+        new_output = repository / "config" / "forced-new-workflow.yaml"
+        forced_new_plan = setup.plan(
+            replace(request, output_path=new_output)
+        )
+        forced_new = setup.apply(
+            HarnessApplyRequest(plan=forced_new_plan, confirmed=True, force=True)
+        )
+        assert forced_new.workflow_action == "created"
+
+        existing_plan = setup.plan(request)
+        with pytest.raises(ProjectInitError, match="already exists"):
+            setup.apply(HarnessApplyRequest(plan=existing_plan, confirmed=True))
+
+        replacement_plan = setup.plan(request)
+        replaced = setup.apply(
+            HarnessApplyRequest(plan=replacement_plan, confirmed=True, force=True)
+        )
+        assert replaced.workflow_action == "replaced"
+        assert replaced.changed is True
+
+
+def test_harness_setup_rejects_a_tampered_or_stale_assessment_before_writing() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = root / "project"
+        repository.mkdir()
+        setup = HarnessSetup()
+        plan = setup.plan(HarnessSetupRequest(repository=repository))
+        outside = root / "outside" / "workflow.yaml"
+        tampered = replace(
+            plan,
+            assessment=replace(
+                plan.assessment,
+                workflow_path=str(outside),
+                suggestions=plan.assessment.suggestions + 1,
+            ),
+        )
+
+        with pytest.raises(ValueError, match="assessment"):
+            setup.apply(HarnessApplyRequest(plan=tampered, confirmed=True))
+
+        assert not outside.exists()
+        assert not (repository / ".ai-workbench" / "workflow.yaml").exists()
+
+
+def test_harness_setup_verify_returns_structured_non_executing_result() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = root / "project"
+        repository.mkdir()
+        subprocess.run(
+            ["git", "init", "-b", "main"],
+            cwd=str(repository),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        marker = root / "command-was-executed"
+        command = repository / "verify.sh"
+        command.write_text(f"#!/bin/sh\ntouch '{marker}'\n", encoding="utf-8")
+        command.chmod(0o755)
+        workflow = repository / "workflow.yaml"
+        workflow.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "status": "approved",
+                    "project": {"root": str(repository), "trusted": True},
+                    "capabilities": {
+                        "commands": {
+                            "unit": {
+                                "argv": [str(command)],
+                                "approved": True,
+                            }
+                        },
+                        "skills": {},
+                    },
+                    "harness": {"profiles": {}},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        result = HarnessSetup().verify(
+            HarnessVerifyRequest(
+                config_path=workflow,
+                codex_bin=sys.executable,
+            )
+        )
+
+        assert result.state == "verified"
+        assert result.config_path == str(workflow.resolve())
+        assert result.report.status == "ok"
+        assert not marker.exists()
+
+
+def test_harness_setup_verify_preserves_a_failed_doctor_report() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "project"
+        repository.mkdir()
+        workflow = repository / "workflow.yaml"
+        workflow.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "status": "draft",
+                    "project": {"root": str(repository), "trusted": False},
+                    "capabilities": {"commands": {}, "skills": {}},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        result = HarnessSetup().verify(
+            HarnessVerifyRequest(
+                config_path=workflow,
+                codex_bin=sys.executable,
+            )
+        )
+
+        assert result.state == "verification_failed"
+        assert result.report.status == "failed"
+        assert any(check.status == "fail" for check in result.report.checks)


### PR DESCRIPTION
## Summary
- introduce structured HarnessSetup inspect, plan, apply, and verify lifecycle results
- route setup, initialization, and doctor CLI behavior through the new seam
- preserve WorkbenchSetup as a compatibility adapter and add interface-level state tests

## Test plan
- `PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m pytest -q` -> 137 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m compileall -q src tests`
- `git diff --check origin/main...HEAD`

Closes #18