### PR TITLE
feat: add Python L0 Harness planning

### DIFF
--- a/.codex/skills/setup-ai-workbench/SKILL.md
+++ b/.codex/skills/setup-ai-workbench/SKILL.md
@@ -32,6 +32,31 @@ suggestions, and optional Skill packs. The inspect command is read-only. Treat
 both Codex and Claude Code as choices the user may select; do not edit global
 Agent configuration.
 
+For a reviewable Python L0 Project Profile and Harness Plan, use:
+
+```bash
+aiwb setup --repo /path/to/repository --planning-mode python-l0
+```
+
+This planning path discovers Python targets, purpose tags, existing engineering
+tools, pipeline files, bounded local Git history, fallback code structure, and
+missing L0 capabilities. It does not execute project commands, query remote
+review history, persist a code graph, create a worktree, or modify the target
+repository. The equivalent MCP tool is `aiwb_harness_plan`; it always returns
+an unapproved Plan.
+
+After reviewing every command candidate, coverage decision, owner decision, and
+non-goal, record explicit Plan Approval outside the target repository:
+
+```bash
+aiwb setup --repo /path/to/repository --planning-mode python-l0 \
+  --approve-plan --approved-by owner \
+  --plan-artifact /path/outside/repository/approved-plan.json
+```
+
+Plan Approval is durable planning state only. It does not authorize Apply,
+execute probes, or create a Candidate.
+
 ## Confirm before applying
 
 If the user wants a project-local draft workflow, state exactly what will be

--- a/tools/agent-orchestrator/README.md
+++ b/tools/agent-orchestrator/README.md
@@ -25,6 +25,29 @@ This interface is currently a compatibility prefactor. Recipe selection,
 dynamic probes, candidate worktrees, and pipeline verification remain later
 delivery slices rather than hidden behavior in setup callers.
 
+The read-only Python L0 planning mode deepens the same interface:
+
+```bash
+aiwb setup --repo /path/to/repository --planning-mode python-l0
+```
+
+It returns a Project Profile and unapproved Harness Plan with target purpose
+tags, L0 capability dispositions, command candidates, Recipe versions,
+coverage and owner decisions, bounded local Git history, pipeline metadata,
+and explicit unavailable evidence. An optional analysis Adapter can supply
+code-graph and remote-review evidence; filesystem and local Git inspection are
+the honest fallback. The equivalent MCP tool is `aiwb_harness_plan`.
+
+After review, Plan Approval is recorded outside the target repository:
+
+```bash
+aiwb setup --repo /path/to/repository --planning-mode python-l0 \
+  --approve-plan --approved-by owner \
+  --plan-artifact /path/outside/repository/approved-plan.json
+```
+
+Plan Approval does not authorize Apply, run probes, or create a Candidate.
+
 `GoalRunner.run(contract)` is the execution interface and test surface. It hides Contract validation, checkpoint persistence, Git worktree management, RED/GREEN machine gates, role prompts, Evidence capture, and recovery.
 
 `DaemonClient.submit/status/report/evidence` is the control interface. It hides the Unix socket protocol, background queue, SQLite job state, thread pool, stale socket handling, content-addressed Evidence retrieval, and process-restart recovery.

--- a/tools/agent-orchestrator/setup.cfg
+++ b/tools/agent-orchestrator/setup.cfg
@@ -12,6 +12,7 @@ package_dir =
 packages = find:
 install_requires =
     PyYAML>=6.0
+    tomli>=2.0; python_version < "3.11"
 
 [options.extras_require]
 test =

--- a/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
+++ b/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
@@ -32,6 +32,31 @@ suggestions, and optional Skill packs. The inspect command is read-only. Treat
 both Codex and Claude Code as choices the user may select; do not edit global
 Agent configuration.
 
+For a reviewable Python L0 Project Profile and Harness Plan, use:
+
+```bash
+aiwb setup --repo /path/to/repository --planning-mode python-l0
+```
+
+This planning path discovers Python targets, purpose tags, existing engineering
+tools, pipeline files, bounded local Git history, fallback code structure, and
+missing L0 capabilities. It does not execute project commands, query remote
+review history, persist a code graph, create a worktree, or modify the target
+repository. The equivalent MCP tool is `aiwb_harness_plan`; it always returns
+an unapproved Plan.
+
+After reviewing every command candidate, coverage decision, owner decision, and
+non-goal, record explicit Plan Approval outside the target repository:
+
+```bash
+aiwb setup --repo /path/to/repository --planning-mode python-l0 \
+  --approve-plan --approved-by owner \
+  --plan-artifact /path/outside/repository/approved-plan.json
+```
+
+Plan Approval is durable planning state only. It does not authorize Apply,
+execute probes, or create a Candidate.
+
 ## Confirm before applying
 
 If the user wants a project-local draft workflow, state exactly what will be

--- a/tools/agent-orchestrator/src/aiwb/__init__.py
+++ b/tools/agent-orchestrator/src/aiwb/__init__.py
@@ -31,6 +31,7 @@ from .harness import (
     HarnessRequest,
     LocalProcessHarness,
 )
+from ._python_setup import CodeStructureEvidence, ExternalAnalysisEvidence
 from .harness_setup import (
     HarnessApplyRequest,
     HarnessAssessment,
@@ -100,8 +101,10 @@ __all__ = [
     "ClaudeCodeCliAdapter",
     "CodexCliAdapter",
     "CommandEvidence",
+    "CodeStructureEvidence",
     "ContractError",
     "ExecutionEnvelope",
+    "ExternalAnalysisEvidence",
     "EvidenceError",
     "EvidenceIntegrityError",
     "EvidencePayload",

--- a/tools/agent-orchestrator/src/aiwb/_python_setup.py
+++ b/tools/agent-orchestrator/src/aiwb/_python_setup.py
@@ -1,0 +1,621 @@
+from __future__ import annotations
+
+import configparser
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional, Tuple
+
+try:
+    import tomllib
+except ImportError:  # pragma: no cover - Python 3.9 and 3.10
+    import tomli as tomllib
+
+
+@dataclass(frozen=True)
+class CapabilityAssessment:
+    name: str
+    disposition: str
+    command: Tuple[str, ...]
+    evidence: Tuple[str, ...]
+    confidence: str
+    reason: str
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "name": self.name,
+            "disposition": self.disposition,
+            "command": list(self.command),
+            "evidence": list(self.evidence),
+            "confidence": self.confidence,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class TargetProfile:
+    path: str
+    language: str
+    purpose_tags: Tuple[str, ...]
+    capabilities: Tuple[CapabilityAssessment, ...]
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "path": self.path,
+            "language": self.language,
+            "purpose_tags": list(self.purpose_tags),
+            "capabilities": [
+                capability.to_dict() for capability in self.capabilities
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class EvidenceStatus:
+    name: str
+    status: str
+    detail: str
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class CodeStructureEvidence:
+    provider: str
+    confidence: str
+    source_roots: Tuple[str, ...]
+    test_roots: Tuple[str, ...]
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "provider": self.provider,
+            "confidence": self.confidence,
+            "source_roots": list(self.source_roots),
+            "test_roots": list(self.test_roots),
+        }
+
+
+@dataclass(frozen=True)
+class ExternalAnalysisEvidence:
+    code_structure: Optional[CodeStructureEvidence] = None
+    remote_review_history: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ProjectProfile:
+    repository: str
+    targets: Tuple[TargetProfile, ...]
+    build_system: str
+    pipeline_files: Tuple[str, ...]
+    git_history: Tuple[str, ...]
+    remote_review_history: Tuple[str, ...]
+    code_structure: CodeStructureEvidence
+    unavailable_evidence: Tuple[EvidenceStatus, ...]
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "repository": self.repository,
+            "targets": [target.to_dict() for target in self.targets],
+            "build_system": self.build_system,
+            "pipeline_files": list(self.pipeline_files),
+            "git_history": list(self.git_history),
+            "remote_review_history": list(self.remote_review_history),
+            "code_structure": self.code_structure.to_dict(),
+            "unavailable_evidence": [
+                evidence.to_dict() for evidence in self.unavailable_evidence
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class CommandCandidate:
+    name: str
+    argv: Tuple[str, ...]
+    working_directory: str
+    source: str
+    confidence: str
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "name": self.name,
+            "argv": list(self.argv),
+            "working_directory": self.working_directory,
+            "source": self.source,
+            "confidence": self.confidence,
+        }
+
+
+@dataclass(frozen=True)
+class PythonPlanningResult:
+    profile: ProjectProfile
+    command_candidates: Tuple[CommandCandidate, ...]
+    owner_decisions: Tuple[str, ...]
+
+
+def inspect_python_l0(
+    repository: Path,
+    external_analysis: Optional[ExternalAnalysisEvidence] = None,
+    analysis_error: str = "",
+) -> PythonPlanningResult:
+    repository = Path(repository).expanduser().resolve()
+    target_roots = _python_target_roots(repository)
+    if not target_roots:
+        raise ValueError("python-l0 planning requires a Python project target")
+
+    targets = []
+    build_systems = []
+    all_source_roots = []
+    all_test_roots = []
+    for root in target_roots:
+        metadata = _target_metadata(root)
+        capabilities = _capabilities(metadata)
+        relative_root = _relative(root, repository)
+        purpose_tags = _purpose_tags(root, metadata)
+        targets.append(
+            TargetProfile(
+                path=relative_root,
+                language="python",
+                purpose_tags=purpose_tags,
+                capabilities=capabilities,
+            )
+        )
+        if metadata.build_backend:
+            build_systems.append(metadata.build_backend)
+        all_source_roots.extend(
+            _relative(path, repository)
+            for path in _source_roots(root)
+        )
+        all_test_roots.extend(
+            _relative(path, repository)
+            for path in _test_roots(root)
+        )
+
+    pipeline_files = tuple(
+        sorted(
+            _relative(path, repository)
+            for pattern in (
+                ".github/workflows/*",
+                ".gitlab-ci.yml",
+                "Jenkinsfile",
+                "buildkite.yml",
+            )
+            for path in repository.glob(pattern)
+            if path.is_file()
+        )
+    )
+    git_history, history_status = _bounded_git_history(repository)
+    fallback_structure = CodeStructureEvidence(
+        provider="filesystem",
+        confidence="medium",
+        source_roots=tuple(sorted(set(all_source_roots))),
+        test_roots=tuple(sorted(set(all_test_roots))),
+    )
+    code_structure = (
+        external_analysis.code_structure
+        if external_analysis is not None
+        and external_analysis.code_structure is not None
+        else fallback_structure
+    )
+    remote_review_history = (
+        external_analysis.remote_review_history
+        if external_analysis is not None
+        else ()
+    )
+    unavailable = []
+    if code_structure == fallback_structure:
+        unavailable.append(
+            EvidenceStatus(
+                name="code_graph",
+                status="unavailable",
+                detail=(
+                    analysis_error
+                    or (
+                        "No approved code-graph analysis result was supplied; "
+                        "filesystem structure was used."
+                    )
+                ),
+            )
+        )
+    if not remote_review_history:
+        unavailable.append(
+            EvidenceStatus(
+                name="remote_review_history",
+                status="unavailable",
+                detail=(
+                    analysis_error
+                    or (
+                        "Remote review history was not queried during read-only "
+                        "repository assessment."
+                    )
+                ),
+            )
+        )
+    if history_status is not None:
+        unavailable.append(history_status)
+    profile = ProjectProfile(
+        repository=str(repository),
+        targets=tuple(targets),
+        build_system=", ".join(sorted(set(build_systems))) or "unknown",
+        pipeline_files=pipeline_files,
+        git_history=git_history,
+        remote_review_history=remote_review_history,
+        code_structure=code_structure,
+        unavailable_evidence=tuple(unavailable),
+    )
+    return planning_from_profile(profile)
+
+
+def planning_from_profile(profile: ProjectProfile) -> PythonPlanningResult:
+    command_candidates = tuple(
+        CommandCandidate(
+            name=(
+                capability.name
+                if target.path == "."
+                else f"{target.path}:{capability.name}"
+            ),
+            argv=capability.command,
+            working_directory=target.path,
+            source=capability.evidence[0],
+            confidence=capability.confidence,
+        )
+        for target in profile.targets
+        for capability in target.capabilities
+        if capability.command
+    )
+    owner_decisions = tuple(
+        decision
+        for decision in (
+            (
+                "Confirm the canonical lint and formatting commands."
+                if any(
+                    capability.name in {"lint", "format"}
+                    and capability.disposition != "keep"
+                    for target in profile.targets
+                    for capability in target.capabilities
+                )
+                else ""
+            ),
+            "Approve a measured coverage baseline before setting a threshold.",
+            (
+                "Confirm whether static type checking is required for this target."
+                if any(
+                    capability.name == "typecheck"
+                    and capability.disposition == "adopt"
+                    for target in profile.targets
+                    for capability in target.capabilities
+                )
+                else ""
+            ),
+        )
+        if decision
+    )
+    return PythonPlanningResult(
+        profile=profile,
+        command_candidates=command_candidates,
+        owner_decisions=owner_decisions,
+    )
+
+
+@dataclass(frozen=True)
+class _TargetMetadata:
+    build_backend: str
+    dependencies: Tuple[str, ...]
+    sections: Tuple[str, ...]
+    entry_points: Tuple[str, ...]
+
+
+def _python_target_roots(repository: Path) -> Tuple[Path, ...]:
+    roots = {
+        path.parent
+        for name in ("pyproject.toml", "setup.cfg")
+        for path in repository.glob(f"**/{name}")
+        if not set(path.relative_to(repository).parts) & _IGNORED_DIRECTORY_NAMES
+    }
+    return tuple(
+        sorted(
+            roots,
+            key=lambda path: (
+                len(path.relative_to(repository).parts),
+                path.as_posix(),
+            ),
+        )
+    )
+
+
+_IGNORED_DIRECTORY_NAMES = frozenset(
+    {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "build",
+        "dist",
+        "node_modules",
+        "venv",
+    }
+)
+
+
+def _target_metadata(root: Path) -> _TargetMetadata:
+    build_backend = ""
+    dependencies = []
+    sections = []
+    entry_points = []
+    pyproject = root / "pyproject.toml"
+    if pyproject.is_file():
+        try:
+            data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+            raise ValueError(f"cannot parse {pyproject}: {error}") from error
+        build = data.get("build-system", {})
+        if isinstance(build, dict):
+            backend = build.get("build-backend")
+            if isinstance(backend, str):
+                build_backend = backend
+        project = data.get("project", {})
+        if isinstance(project, dict):
+            dependencies.extend(_strings(project.get("dependencies")))
+            optional = project.get("optional-dependencies", {})
+            if isinstance(optional, dict):
+                for values in optional.values():
+                    dependencies.extend(_strings(values))
+            scripts = project.get("scripts", {})
+            if isinstance(scripts, dict):
+                entry_points.extend(str(name) for name in scripts)
+        tool = data.get("tool", {})
+        if isinstance(tool, dict):
+            sections.extend(str(name).lower() for name in tool)
+
+    setup_cfg = root / "setup.cfg"
+    if setup_cfg.is_file():
+        parser = configparser.ConfigParser()
+        try:
+            parser.read(setup_cfg, encoding="utf-8")
+        except configparser.Error as error:
+            raise ValueError(f"cannot parse {setup_cfg}: {error}") from error
+        sections.extend(section.lower() for section in parser.sections())
+        for section in ("options", "options.extras_require"):
+            if parser.has_section(section):
+                for _, value in parser.items(section):
+                    dependencies.extend(
+                        line.strip()
+                        for line in value.splitlines()
+                        if line.strip()
+                    )
+        if parser.has_section("options.entry_points"):
+            entry_points.extend(name for name, _ in parser.items("options.entry_points"))
+
+    return _TargetMetadata(
+        build_backend=build_backend,
+        dependencies=tuple(dependencies),
+        sections=tuple(sections),
+        entry_points=tuple(entry_points),
+    )
+
+
+def _capabilities(
+    metadata: _TargetMetadata,
+) -> Tuple[CapabilityAssessment, ...]:
+    dependency_text = " ".join(metadata.dependencies).lower()
+    sections = set(metadata.sections)
+    has_pytest = "pytest" in dependency_text or "pytest" in sections
+    has_ruff = "ruff" in dependency_text or "ruff" in sections
+    has_flake8 = "flake8" in dependency_text or "flake8" in sections
+    has_black = "black" in dependency_text or "black" in sections
+    has_coverage = (
+        "pytest-cov" in dependency_text
+        or "coverage" in dependency_text
+        or "coverage" in sections
+    )
+    type_tool = next(
+        (
+            name
+            for name in ("mypy", "pyright")
+            if name in dependency_text or name in sections
+        ),
+        ""
+    )
+    capabilities = [
+        _capability(
+            "unit",
+            "keep" if has_pytest else "adopt",
+            (sys.executable, "-m", "pytest", "-q"),
+            "pytest project metadata" if has_pytest else "Python target structure",
+            "high" if has_pytest else "medium",
+            "Preserve the existing Pytest path."
+            if has_pytest
+            else "No project-owned unit test runner was detected.",
+        ),
+        _capability(
+            "lint",
+            "keep" if has_flake8 or has_ruff else "adopt",
+            (
+                (sys.executable, "-m", "flake8", ".")
+                if has_flake8
+                else (sys.executable, "-m", "ruff", "check", ".")
+            ),
+            (
+                "Flake8 project metadata"
+                if has_flake8
+                else "Ruff project metadata"
+                if has_ruff
+                else "Python target structure"
+            ),
+            "high" if has_flake8 or has_ruff else "medium",
+            "Preserve the existing Flake8 lint path."
+            if has_flake8
+            else "Preserve the existing Ruff lint path."
+            if has_ruff
+            else "No project-owned lint tool was detected.",
+        ),
+        _capability(
+            "format",
+            "keep" if has_black or has_ruff else "adopt",
+            (
+                (sys.executable, "-m", "black", "--check", ".")
+                if has_black
+                else (sys.executable, "-m", "ruff", "format", "--check", ".")
+            ),
+            (
+                "Black project metadata"
+                if has_black
+                else "Ruff project metadata"
+                if has_ruff
+                else "Python target structure"
+            ),
+            "high" if has_black or has_ruff else "medium",
+            "Preserve the existing Black formatter."
+            if has_black
+            else "Preserve the existing Ruff formatter."
+            if has_ruff
+            else "No project-owned formatting tool was detected.",
+        ),
+        _capability(
+            "typecheck",
+            "keep" if type_tool else "adopt",
+            (
+                (sys.executable, "-m", type_tool, ".")
+                if type_tool
+                else (sys.executable, "-m", "mypy", ".")
+            ),
+            f"{type_tool} project metadata" if type_tool else "Python target structure",
+            "high" if type_tool else "low",
+            f"Preserve the existing {type_tool} path."
+            if type_tool
+            else "No project-owned type checker was detected.",
+        ),
+        _capability(
+            "coverage",
+            "augment" if has_coverage else "adopt",
+            (
+                sys.executable,
+                "-m",
+                "pytest",
+                "--cov",
+                "--cov-report=xml",
+            ),
+            (
+                "coverage project metadata"
+                if has_coverage
+                else "Python target structure"
+            ),
+            "high" if has_coverage else "low",
+            (
+                "Coverage tooling exists, but the measured baseline and "
+                "threshold remain owner decisions."
+                if has_coverage
+                else "No project-owned coverage tool was detected."
+            ),
+        ),
+    ]
+    if has_flake8 and has_ruff:
+        capabilities.append(
+            _capability(
+                "ruff_lint_migration",
+                "migrate_later",
+                (sys.executable, "-m", "ruff", "check", "."),
+                "Flake8 and Ruff project metadata",
+                "high",
+                "Keep Flake8 working; evaluate Ruff consolidation separately.",
+            )
+        )
+    if has_black and has_ruff:
+        capabilities.append(
+            _capability(
+                "ruff_format_migration",
+                "migrate_later",
+                (sys.executable, "-m", "ruff", "format", "--check", "."),
+                "Black and Ruff project metadata",
+                "high",
+                "Keep Black working; evaluate Ruff consolidation separately.",
+            )
+        )
+    return tuple(capabilities)
+
+
+def _capability(
+    name: str,
+    disposition: str,
+    command: Tuple[str, ...],
+    evidence: str,
+    confidence: str,
+    reason: str,
+) -> CapabilityAssessment:
+    return CapabilityAssessment(
+        name=name,
+        disposition=disposition,
+        command=command,
+        evidence=(evidence,),
+        confidence=confidence,
+        reason=reason,
+    )
+
+
+def _purpose_tags(root: Path, metadata: _TargetMetadata) -> Tuple[str, ...]:
+    tags = []
+    if _source_roots(root):
+        tags.append("library")
+    if _test_roots(root):
+        tags.append("test")
+    if metadata.entry_points:
+        tags.append("cli")
+    return tuple(tags or ["library"])
+
+
+def _source_roots(root: Path) -> Tuple[Path, ...]:
+    candidates = [root / "src"]
+    return tuple(path for path in candidates if path.is_dir())
+
+
+def _test_roots(root: Path) -> Tuple[Path, ...]:
+    candidates = [root / "tests", root / "test"]
+    return tuple(path for path in candidates if path.is_dir())
+
+
+def _bounded_git_history(
+    repository: Path,
+) -> Tuple[Tuple[str, ...], Optional[EvidenceStatus]]:
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "log",
+            "--max-count=20",
+            "--format=%H%x09%s",
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=5,
+    )
+    if completed.returncode != 0:
+        return (), EvidenceStatus(
+            name="local_git_history",
+            status="unavailable",
+            detail="The repository has no readable local Git history.",
+        )
+    return (
+        tuple(line for line in completed.stdout.splitlines() if line),
+        None,
+    )
+
+
+def _strings(value: object) -> Tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str))
+
+
+def _relative(path: Path, repository: Path) -> str:
+    relative = path.relative_to(repository).as_posix()
+    return relative or "."

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -81,6 +81,10 @@ def _build_parser() -> argparse.ArgumentParser:
     setup.add_argument("--install-pack", action="append", default=[])
     setup.add_argument("--pack-skill", action="append", default=[])
     setup.add_argument("--pack-profile", action="append", default=[])
+    setup.add_argument("--planning-mode", choices=("python-l0",))
+    setup.add_argument("--approve-plan", action="store_true")
+    setup.add_argument("--approved-by")
+    setup.add_argument("--plan-artifact", type=Path)
     setup.add_argument("--apply", action="store_true")
 
     skills = commands.add_parser("skills")
@@ -245,8 +249,32 @@ def _run_setup(options: argparse.Namespace) -> int:
         HarnessSetupRequest(
             repository=options.repo,
             agent_targets=targets,
+            planning_mode=options.planning_mode or "",
         )
     )
+    if options.planning_mode:
+        if options.apply:
+            raise ValueError(
+                "planning mode is read-only and cannot be combined with --apply"
+            )
+        if options.approve_plan:
+            if not options.approved_by or options.plan_artifact is None:
+                raise ValueError(
+                    "Plan Approval requires --approved-by and --plan-artifact"
+                )
+            plan = setup.approve_plan(
+                plan,
+                approved_by=options.approved_by,
+                artifact_path=options.plan_artifact,
+            )
+        elif options.approved_by or options.plan_artifact is not None:
+            raise ValueError(
+                "--approved-by and --plan-artifact require --approve-plan"
+            )
+        _print_json(plan.to_dict())
+        return 0
+    if options.approve_plan or options.approved_by or options.plan_artifact is not None:
+        raise ValueError("Plan Approval requires --planning-mode")
     role_skills = _role_skills(options.role_skill)
     pack_skills = _pack_skills(options.install_pack, options.pack_skill)
     pack_profiles = _pack_profiles(options.install_pack, options.pack_profile)

--- a/tools/agent-orchestrator/src/aiwb/harness_setup.py
+++ b/tools/agent-orchestrator/src/aiwb/harness_setup.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+import json
+import os
 import subprocess
+import tempfile
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Mapping, Optional, Sequence, Tuple
 
 import yaml
 
+from ._python_setup import (
+    CommandCandidate,
+    ExternalAnalysisEvidence,
+    ProjectProfile,
+    inspect_python_l0,
+    planning_from_profile,
+)
 from .project import DoctorReport, ProjectDoctor, ProjectInitializer
 from .skills import (
     SkillCatalog,
@@ -22,6 +33,7 @@ class HarnessSetupRequest:
     agent_targets: Tuple[str, ...] = ()
     operation: str = "setup"
     output_path: Optional[Path] = None
+    planning_mode: str = ""
 
 
 @dataclass(frozen=True)
@@ -34,6 +46,38 @@ class HarnessAssessment:
     agent_targets: Tuple[str, ...]
     catalog: SkillCatalogSnapshot
     packs: Tuple[SkillPackDescriptor, ...]
+    project_profile: Optional[ProjectProfile] = None
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "state": self.state,
+            "repository": self.repository,
+            "workflow_action": self.workflow_action,
+            "workflow_path": self.workflow_path,
+            "suggestions": self.suggestions,
+            "agent_targets": list(self.agent_targets),
+            "project_profile": (
+                self.project_profile.to_dict()
+                if self.project_profile is not None
+                else None
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class PlanApproval:
+    status: str
+    approved_by: str = ""
+    approved_at: str = ""
+    artifact_path: str = ""
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "status": self.status,
+            "approved_by": self.approved_by,
+            "approved_at": self.approved_at,
+            "artifact_path": self.artifact_path,
+        }
 
 
 @dataclass(frozen=True)
@@ -41,6 +85,40 @@ class HarnessPlan:
     state: str
     request: HarnessSetupRequest
     assessment: HarnessAssessment
+    command_candidates: Tuple[CommandCandidate, ...] = ()
+    recipe_versions: Tuple[Tuple[str, int], ...] = ()
+    coverage_decision: str = ""
+    owner_decisions: Tuple[str, ...] = ()
+    non_goals: Tuple[str, ...] = ()
+    approval: PlanApproval = PlanApproval(status="unapproved")
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "state": self.state,
+            "request": {
+                "repository": str(Path(self.request.repository).expanduser().resolve()),
+                "agent_targets": list(self.request.agent_targets),
+                "operation": self.request.operation,
+                "output_path": (
+                    str(Path(self.request.output_path).expanduser().resolve())
+                    if self.request.output_path is not None
+                    else None
+                ),
+                "planning_mode": self.request.planning_mode,
+            },
+            "assessment": self.assessment.to_dict(),
+            "command_candidates": [
+                candidate.to_dict() for candidate in self.command_candidates
+            ],
+            "recipe_versions": [
+                {"name": name, "version": version}
+                for name, version in self.recipe_versions
+            ],
+            "coverage_decision": self.coverage_decision,
+            "owner_decisions": list(self.owner_decisions),
+            "non_goals": list(self.non_goals),
+            "approval": self.approval.to_dict(),
+        }
 
 
 @dataclass(frozen=True)
@@ -90,15 +168,21 @@ class HarnessSetup:
         catalog: Optional[SkillCatalog] = None,
         pack_catalog: Optional[SkillPackCatalog] = None,
         command_runner: Optional[Callable[[Tuple[str, ...], Path], None]] = None,
+        analysis_provider: Optional[
+            Callable[[Path], ExternalAnalysisEvidence]
+        ] = None,
     ) -> None:
         self._catalog = catalog or SkillCatalog()
         self._pack_catalog = pack_catalog or SkillPackCatalog()
         self._command_runner = command_runner or _run_pack_command
+        self._analysis_provider = analysis_provider
         self._initializer = ProjectInitializer()
 
     def inspect(self, request: HarnessSetupRequest) -> HarnessAssessment:
         if request.operation not in {"setup", "initialize"}:
             raise ValueError("Harness setup operation must be setup or initialize")
+        if request.planning_mode not in {"", "python-l0"}:
+            raise ValueError("Harness planning mode must be python-l0")
         if any(
             target not in {"codex", "claude-code"}
             for target in request.agent_targets
@@ -106,6 +190,20 @@ class HarnessSetup:
             raise ValueError("agent targets must be codex or claude-code")
         repository = Path(request.repository).expanduser().resolve()
         preview = self._initializer.preview(repository, request.output_path)
+        planning = None
+        if request.planning_mode == "python-l0":
+            external_analysis = None
+            analysis_error = ""
+            if self._analysis_provider is not None:
+                try:
+                    external_analysis = self._analysis_provider(repository)
+                except Exception as error:
+                    analysis_error = str(error)
+            planning = inspect_python_l0(
+                repository,
+                external_analysis=external_analysis,
+                analysis_error=analysis_error,
+            )
         return HarnessAssessment(
             state="assessed",
             repository=str(repository),
@@ -119,14 +217,94 @@ class HarnessSetup:
             agent_targets=request.agent_targets,
             catalog=self._catalog.inspect(repository),
             packs=self._pack_catalog.inspect(),
+            project_profile=planning.profile if planning is not None else None,
         )
 
     def plan(self, request: HarnessSetupRequest) -> HarnessPlan:
+        assessment = self.inspect(request)
+        planning = (
+            planning_from_profile(assessment.project_profile)
+            if assessment.project_profile is not None
+            else None
+        )
         return HarnessPlan(
             state="planned",
             request=request,
-            assessment=self.inspect(request),
+            assessment=assessment,
+            command_candidates=(
+                planning.command_candidates if planning is not None else ()
+            ),
+            recipe_versions=(
+                (("python-l0-baseline", 1),)
+                if planning is not None
+                else ()
+            ),
+            coverage_decision=(
+                "measure_baseline_before_threshold"
+                if planning is not None
+                else ""
+            ),
+            owner_decisions=(
+                planning.owner_decisions if planning is not None else ()
+            ),
+            non_goals=(
+                (
+                    "Do not write or invent business tests.",
+                    "Do not apply tool migrations or Recipe upgrades.",
+                    "Do not execute project commands or pipeline workflows.",
+                    "Do not create candidate worktrees or modify the repository.",
+                )
+                if planning is not None
+                else ()
+            ),
         )
+
+    def approve_plan(
+        self,
+        plan: HarnessPlan,
+        approved_by: str,
+        approved_at: Optional[datetime] = None,
+        artifact_path: Optional[Path] = None,
+    ) -> HarnessPlan:
+        if plan.state != "planned":
+            raise ValueError("Plan Approval requires a planned Harness Plan")
+        if plan.approval.status != "unapproved":
+            raise ValueError("Harness Plan is already approved")
+        if not approved_by.strip():
+            raise ValueError("Plan Approval requires an approver")
+        if plan.assessment != self.inspect(plan.request):
+            raise ValueError("Harness Plan assessment is stale or has been modified")
+        if artifact_path is None:
+            raise ValueError("Plan Approval requires an explicit artifact path")
+        repository = Path(plan.request.repository).expanduser().resolve()
+        artifact_path = Path(artifact_path).expanduser().resolve()
+        try:
+            artifact_path.relative_to(repository)
+        except ValueError:
+            pass
+        else:
+            raise ValueError(
+                "Plan Approval artifact must stay outside the target repository"
+            )
+        approved_at = approved_at or datetime.now(timezone.utc)
+        approved = HarnessPlan(
+            state=plan.state,
+            request=plan.request,
+            assessment=plan.assessment,
+            command_candidates=plan.command_candidates,
+            recipe_versions=plan.recipe_versions,
+            coverage_decision=plan.coverage_decision,
+            owner_decisions=plan.owner_decisions,
+            non_goals=plan.non_goals,
+            approval=PlanApproval(
+                status="approved",
+                approved_by=approved_by.strip(),
+                approved_at=approved_at.astimezone(timezone.utc).isoformat(),
+                artifact_path=str(artifact_path),
+            ),
+        )
+        _write_json_atomically(artifact_path, approved.to_dict())
+        return approved
 
     def apply(self, request: HarnessApplyRequest) -> HarnessCandidate:
         if request.plan.state != "planned":
@@ -137,6 +315,11 @@ class HarnessSetup:
         assessment = plan.assessment
         if assessment.state != "assessed":
             raise ValueError("apply requires an assessed Harness Plan")
+        if plan.request.planning_mode:
+            raise ValueError(
+                "an approved Harness Plan does not authorize Apply; "
+                "candidate Apply is a separate lifecycle"
+            )
         repository = Path(plan.request.repository).expanduser().resolve()
         if assessment.repository != str(repository):
             raise ValueError("Harness Plan repository does not match its request")
@@ -308,3 +491,21 @@ def _run_pack_command(command: Tuple[str, ...], repository: Path) -> None:
         )
     except (OSError, subprocess.SubprocessError) as error:
         raise ValueError(f"Skill pack installation failed: {error}") from error
+
+
+def _write_json_atomically(path: Path, value: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(value, output, indent=2, sort_keys=True)
+            output.write("\n")
+        temporary_path.replace(path)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise

--- a/tools/agent-orchestrator/src/aiwb/mcp_server.py
+++ b/tools/agent-orchestrator/src/aiwb/mcp_server.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import IO, Dict, Mapping, Optional, Sequence
 
 from .daemon import DaemonClient, DaemonError
+from .harness_setup import HarnessSetup, HarnessSetupRequest
 from .intake import GoalIntake
 from .runner import preview_execution
 
@@ -91,6 +92,17 @@ class McpServer:
                     "socket": str(self._socket_path),
                     "status": "ok" if self._client.ping() else "unavailable",
                 }
+            elif name == "aiwb_harness_plan":
+                repository = _string_argument(arguments, "repository")
+                planning_mode = arguments.get("planning_mode", "python-l0")
+                if planning_mode != "python-l0":
+                    raise ValueError("planning_mode must be python-l0")
+                value = HarnessSetup().plan(
+                    HarnessSetupRequest(
+                        repository=Path(repository),
+                        planning_mode=planning_mode,
+                    )
+                ).to_dict()
             elif name == "aiwb_goal_preflight":
                 contract_path = _string_argument(arguments, "contract_path")
                 workflow_path = arguments.get("workflow_path")
@@ -206,6 +218,25 @@ def _tools():
                     "artifact_id": string_argument,
                 },
                 "required": ["run_id", "artifact_id"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "aiwb_harness_plan",
+            "description": (
+                "Inspect a repository and return a read-only Harness assessment "
+                "and unapproved Plan without applying changes."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repository": string_argument,
+                    "planning_mode": {
+                        "type": "string",
+                        "enum": ["python-l0"],
+                    },
+                },
+                "required": ["repository"],
                 "additionalProperties": False,
             },
         },

--- a/tools/agent-orchestrator/tests/test_harness_setup.py
+++ b/tools/agent-orchestrator/tests/test_harness_setup.py
@@ -4,8 +4,10 @@ import subprocess
 import sys
 import tempfile
 from dataclasses import replace
+from datetime import datetime, timezone
 from pathlib import Path
 
+import json
 import pytest
 import yaml
 
@@ -14,11 +16,15 @@ sys.path.insert(0, str(TOOL_ROOT / "src"))
 
 from aiwb import (  # noqa: E402
     HarnessApplyRequest,
+    CodeStructureEvidence,
+    ExternalAnalysisEvidence,
     HarnessSetup,
     HarnessSetupRequest,
     HarnessVerifyRequest,
     ProjectInitError,
 )
+from aiwb.cli import main as cli_main  # noqa: E402
+from aiwb.mcp_server import McpServer  # noqa: E402
 
 
 def test_harness_setup_inspect_and_plan_are_read_only() -> None:
@@ -50,6 +56,403 @@ def test_harness_setup_inspect_and_plan_are_read_only() -> None:
         assert plan.assessment == assessment
         assert plan.request == request
         assert not marker.exists()
+        assert not (repository / ".ai-workbench" / "workflow.yaml").exists()
+
+
+def test_harness_setup_plans_a_python_l0_profile_from_repository_evidence() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = root / "project"
+        (repository / "src" / "sample").mkdir(parents=True)
+        (repository / "tests").mkdir()
+        (repository / ".github" / "workflows").mkdir(parents=True)
+        (repository / "pyproject.toml").write_text(
+            "[build-system]\n"
+            "requires = ['setuptools>=68']\n"
+            "build-backend = 'setuptools.build_meta'\n\n"
+            "[project]\n"
+            "name = 'sample'\n"
+            "dependencies = []\n\n"
+            "[project.optional-dependencies]\n"
+            "test = ['pytest>=8', 'pytest-cov>=5', 'ruff==0.12.4']\n\n"
+            "[tool.pytest.ini_options]\n"
+            "testpaths = ['tests']\n\n"
+            "[tool.ruff]\n"
+            "line-length = 88\n",
+            encoding="utf-8",
+        )
+        (repository / ".github" / "workflows" / "test.yml").write_text(
+            "name: test\non: [push]\n",
+            encoding="utf-8",
+        )
+        marker = root / "command-was-executed"
+        script = repository / "test.sh"
+        script.write_text(f"#!/bin/sh\ntouch '{marker}'\n", encoding="utf-8")
+        script.chmod(0o755)
+        subprocess.run(
+            ["git", "init", "-b", "main"],
+            cwd=str(repository),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "add", "."],
+            cwd=str(repository),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=AIWB",
+                "-c",
+                "user.email=aiwb@example.test",
+                "commit",
+                "-m",
+                "Initial fixture",
+            ],
+            cwd=str(repository),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        before = _tree(repository)
+        setup = HarnessSetup()
+        request = HarnessSetupRequest(
+            repository=repository,
+            planning_mode="python-l0",
+        )
+
+        assessment = setup.inspect(request)
+        plan = setup.plan(request)
+
+        profile = assessment.project_profile
+        assert profile is not None
+        assert profile.targets[0].language == "python"
+        assert set(profile.targets[0].purpose_tags) == {"library", "test"}
+        capabilities = {
+            capability.name: capability
+            for capability in profile.targets[0].capabilities
+        }
+        assert capabilities["unit"].disposition == "keep"
+        assert capabilities["lint"].disposition == "keep"
+        assert capabilities["coverage"].disposition == "augment"
+        assert capabilities["typecheck"].disposition == "adopt"
+        assert capabilities["unit"].confidence == "high"
+        assert profile.build_system == "setuptools.build_meta"
+        assert profile.pipeline_files == (".github/workflows/test.yml",)
+        assert {item.name for item in profile.unavailable_evidence} == {
+            "code_graph",
+            "remote_review_history",
+        }
+        assert profile.code_structure.provider == "filesystem"
+        assert profile.code_structure.confidence == "medium"
+        assert plan.command_candidates
+        assert plan.recipe_versions == (("python-l0-baseline", 1),)
+        assert plan.coverage_decision == "measure_baseline_before_threshold"
+        assert plan.owner_decisions
+        assert "business tests" in " ".join(plan.non_goals).lower()
+        assert plan.approval.status == "unapproved"
+        assert _tree(repository) == before
+        assert not marker.exists()
+
+
+def test_python_l0_prefers_available_code_graph_and_review_evidence() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "project"
+        (repository / "src" / "sample").mkdir(parents=True)
+        (repository / "tests").mkdir()
+        (repository / "pyproject.toml").write_text(
+            "[build-system]\n"
+            "requires = ['setuptools>=68']\n"
+            "build-backend = 'setuptools.build_meta'\n\n"
+            "[tool.pytest.ini_options]\n"
+            "testpaths = ['tests']\n",
+            encoding="utf-8",
+        )
+
+        calls = []
+
+        def analyze(path: Path) -> ExternalAnalysisEvidence:
+            calls.append(path)
+            return ExternalAnalysisEvidence(
+                code_structure=CodeStructureEvidence(
+                    provider="codebase-memory",
+                    confidence="high",
+                    source_roots=("src/sample",),
+                    test_roots=("tests",),
+                ),
+                remote_review_history=("PR #7: preserve pytest",),
+            )
+
+        profile = HarnessSetup(analysis_provider=analyze).inspect(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        ).project_profile
+
+        assert profile is not None
+        assert calls == [repository.resolve()]
+        assert profile.code_structure.provider == "codebase-memory"
+        assert profile.code_structure.confidence == "high"
+        assert profile.remote_review_history == ("PR #7: preserve pytest",)
+        assert {
+            item.name for item in profile.unavailable_evidence
+        } == {"local_git_history"}
+
+
+def test_python_l0_reports_analysis_provider_failure_and_falls_back() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "project"
+        (repository / "tests").mkdir(parents=True)
+        (repository / "pyproject.toml").write_text(
+            "[tool.pytest.ini_options]\ntestpaths = ['tests']\n",
+            encoding="utf-8",
+        )
+
+        def unavailable(_: Path) -> ExternalAnalysisEvidence:
+            raise RuntimeError("analysis provider unavailable")
+
+        profile = HarnessSetup(analysis_provider=unavailable).inspect(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        ).project_profile
+
+        assert profile is not None
+        assert profile.code_structure.provider == "filesystem"
+        assert profile.code_structure.confidence == "medium"
+        code_graph = next(
+            item
+            for item in profile.unavailable_evidence
+            if item.name == "code_graph"
+        )
+        assert code_graph.status == "unavailable"
+        assert "analysis provider unavailable" in code_graph.detail
+
+
+def test_python_l0_preserves_existing_tools_and_defers_migration() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "project"
+        (repository / "tests").mkdir(parents=True)
+        (repository / "pyproject.toml").write_text(
+            "[project]\n"
+            "name = 'sample'\n\n"
+            "[project.optional-dependencies]\n"
+            "test = ['pytest>=8', 'ruff==0.12.4', 'black==25.1', 'flake8==7.3']\n\n"
+            "[tool.pytest.ini_options]\n"
+            "testpaths = ['tests']\n",
+            encoding="utf-8",
+        )
+
+        profile = HarnessSetup().inspect(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        ).project_profile
+
+        assert profile is not None
+        capabilities = {
+            capability.name: capability
+            for capability in profile.targets[0].capabilities
+        }
+        assert capabilities["lint"].disposition == "keep"
+        assert capabilities["lint"].command[-2:] == ("flake8", ".")
+        assert capabilities["format"].disposition == "keep"
+        assert capabilities["format"].command[-3:] == ("black", "--check", ".")
+        assert capabilities["ruff_lint_migration"].disposition == "migrate_later"
+        assert capabilities["ruff_format_migration"].disposition == "migrate_later"
+
+
+def test_python_l0_command_candidates_include_nested_target_working_directory() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "repository"
+        target = repository / "tools" / "python-app"
+        (target / "tests").mkdir(parents=True)
+        (target / "pyproject.toml").write_text(
+            "[tool.pytest.ini_options]\ntestpaths = ['tests']\n",
+            encoding="utf-8",
+        )
+
+        plan = HarnessSetup().plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+
+        unit = next(
+            candidate
+            for candidate in plan.command_candidates
+            if candidate.name == "tools/python-app:unit"
+        )
+        assert unit.working_directory == "tools/python-app"
+        assert unit.to_dict()["working_directory"] == "tools/python-app"
+
+
+def test_python_l0_ignores_generated_and_dependency_directories() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "repository"
+        (repository / "tests").mkdir(parents=True)
+        (repository / "pyproject.toml").write_text(
+            "[tool.pytest.ini_options]\ntestpaths = ['tests']\n",
+            encoding="utf-8",
+        )
+        for generated in (".venv", "venv", "node_modules", "build", "dist"):
+            target = repository / generated / "dependency"
+            target.mkdir(parents=True)
+            (target / "pyproject.toml").write_text(
+                "[project]\nname = 'dependency'\n",
+                encoding="utf-8",
+            )
+
+        profile = HarnessSetup().inspect(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        ).project_profile
+
+        assert profile is not None
+        assert tuple(target.path for target in profile.targets) == (".",)
+
+
+def test_python_l0_plan_approval_is_durable_but_does_not_authorize_apply() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = root / "project"
+        (repository / "tests").mkdir(parents=True)
+        (repository / "pyproject.toml").write_text(
+            "[build-system]\n"
+            "requires = ['setuptools>=68']\n"
+            "build-backend = 'setuptools.build_meta'\n\n"
+            "[tool.pytest.ini_options]\n"
+            "testpaths = ['tests']\n",
+            encoding="utf-8",
+        )
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        artifact = root / "artifacts" / "approved-plan.json"
+
+        approved = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            approved_at=datetime(2026, 7, 28, tzinfo=timezone.utc),
+            artifact_path=artifact,
+        )
+
+        assert approved.approval.status == "approved"
+        assert approved.approval.approved_by == "owner"
+        assert approved.approval.artifact_path == str(artifact.resolve())
+        stored = json.loads(artifact.read_text(encoding="utf-8"))
+        assert stored == approved.to_dict()
+        with pytest.raises(ValueError, match="does not authorize Apply"):
+            setup.apply(HarnessApplyRequest(plan=approved, confirmed=True))
+
+        inside_repository = repository / "approved-plan.json"
+        with pytest.raises(ValueError, match="outside the target repository"):
+            setup.approve_plan(
+                plan,
+                approved_by="owner",
+                artifact_path=inside_repository,
+            )
+        assert not inside_repository.exists()
+
+
+def test_python_l0_cli_and_mcp_return_the_same_unapproved_plan(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        repository = Path(directory) / "project"
+        (repository / "tests").mkdir(parents=True)
+        (repository / "pyproject.toml").write_text(
+            "[build-system]\n"
+            "requires = ['setuptools>=68']\n"
+            "build-backend = 'setuptools.build_meta'\n\n"
+            "[tool.pytest.ini_options]\n"
+            "testpaths = ['tests']\n",
+            encoding="utf-8",
+        )
+
+        returncode = cli_main(
+            [
+                "setup",
+                "--repo",
+                str(repository),
+                "--planning-mode",
+                "python-l0",
+            ]
+        )
+        cli_value = json.loads(capsys.readouterr().out)
+        mcp_result = McpServer(Path(directory) / "missing.sock")._call_tool(
+            "aiwb_harness_plan",
+            {
+                "repository": str(repository),
+                "planning_mode": "python-l0",
+            },
+        )
+        mcp_value = json.loads(mcp_result["content"][0]["text"])
+
+        assert returncode == 0
+        assert mcp_result["isError"] is False
+        assert cli_value == mcp_value
+        assert cli_value["approval"]["status"] == "unapproved"
+        assert not (repository / ".ai-workbench" / "workflow.yaml").exists()
+
+
+def test_python_l0_cli_records_explicit_plan_approval(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = root / "project"
+        (repository / "tests").mkdir(parents=True)
+        (repository / "pyproject.toml").write_text(
+            "[build-system]\n"
+            "requires = ['setuptools>=68']\n"
+            "build-backend = 'setuptools.build_meta'\n\n"
+            "[tool.pytest.ini_options]\n"
+            "testpaths = ['tests']\n",
+            encoding="utf-8",
+        )
+        artifact = root / "approved-plan.json"
+
+        returncode = cli_main(
+            [
+                "setup",
+                "--repo",
+                str(repository),
+                "--planning-mode",
+                "python-l0",
+                "--approve-plan",
+                "--approved-by",
+                "owner",
+                "--plan-artifact",
+                str(artifact),
+            ]
+        )
+        value = json.loads(capsys.readouterr().out)
+
+        assert returncode == 0
+        assert value["approval"]["status"] == "approved"
+        assert value["approval"]["approved_by"] == "owner"
+        assert value["approval"]["artifact_path"] == str(artifact.resolve())
+        assert json.loads(artifact.read_text(encoding="utf-8")) == value
         assert not (repository / ".ai-workbench" / "workflow.yaml").exists()
 
 
@@ -231,3 +634,12 @@ def test_harness_setup_verify_preserves_a_failed_doctor_report() -> None:
         assert result.state == "verification_failed"
         assert result.report.status == "failed"
         assert any(check.status == "fail" for check in result.report.checks)
+
+
+def _tree(root: Path) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            str(path.relative_to(root))
+            for path in root.rglob("*")
+        )
+    )

--- a/tools/agent-orchestrator/tests/test_mcp_server.py
+++ b/tools/agent-orchestrator/tests/test_mcp_server.py
@@ -111,6 +111,7 @@ def test_stdio_mcp_lists_tools_and_reports_daemon_status() -> None:
             assert [tool["name"] for tool in listed["result"]["tools"]] == [
                 "aiwb_daemon_status",
                 "aiwb_goal_evidence",
+                "aiwb_harness_plan",
                 "aiwb_goal_intake",
                 "aiwb_goal_preflight",
                 "aiwb_goal_report",


### PR DESCRIPTION
## Summary
- add read-only Python L0 target, purpose, capability, build, pipeline, Git history, and code-structure assessment
- produce reviewable Harness Plans with canonical commands, Recipe versions, coverage and owner decisions, non-goals, and durable external Plan Approval
- expose equivalent CLI, MCP, and setup Skill semantics while keeping Apply separate

## Test plan
- `PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m pytest -q` -> 146 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m compileall -q src tests`
- `diff -q .codex/skills/setup-ai-workbench/SKILL.md tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md`
- `git diff --check origin/main...HEAD`

Closes #19