### PR TITLE
feat: bridge planning handoffs to safe artifacts

### DIFF
--- a/.codex/skills/intake-aiwb-goal/SKILL.md
+++ b/.codex/skills/intake-aiwb-goal/SKILL.md
@@ -31,6 +31,23 @@ aiwb goal intake --repo /path/to/project --contract /path/to/contract.yaml
 Pass the handoff to the shared interface. Do not reimplement schema validation,
 normalization, readiness blockers, or cheapest-path selection in this Skill.
 
+## Create the next safe artifact
+
+After planning intake, use the bridge only with an explicit reviewed policy and
+caller-selected output outside the target repository:
+
+```bash
+aiwb goal bridge --repo /path/to/project \
+  --handoff /path/to/handoff.json \
+  --policy /path/to/reviewed-policy.yaml \
+  --output /path/outside/project/next-artifact.yaml
+```
+
+The equivalent MCP tool is `aiwb_handoff_bridge`. A fully mapped handoff creates
+an unapproved Contract and side-effect-free preflight result. Missing approved
+command mappings or `allowed_paths` creates only a non-executable policy draft.
+Do not invent commands, paths, approvals, provider changes, or placeholders.
+
 ## Interpret
 
 - `interactive` / `interactive_matt`: use the installed `$ask-matt` router, or

--- a/tools/agent-orchestrator/README.md
+++ b/tools/agent-orchestrator/README.md
@@ -379,6 +379,24 @@ Unsupported envelope versions return `unsupported_handoff_schema`. Supported
 but incomplete handoffs return ordinary readiness blockers and warnings.
 Intake remains read-only and does not require a Daemon.
 
+To create the next safe artifact from a reviewed planning handoff:
+
+```bash
+aiwb goal bridge --repo /path/to/project \
+  --handoff /path/to/handoff.json \
+  --policy /path/to/reviewed-policy.yaml \
+  --output /path/outside/project/next-artifact.yaml
+```
+
+Executable v1 handoff Todos may declare `command_name`, which must exactly name
+an approved policy capability, plus a non-empty `allowed_paths` list. When every
+Todo is mapped, the bridge atomically writes an unapproved Contract and runs
+side-effect-free preflight against the explicit policy. Otherwise it writes
+only a clearly marked, non-executable policy draft with provenance, blockers,
+warnings, candidate commands, and review actions. The bridge never invents a
+command or path, writes inside the target repository, starts a Daemon or Agent,
+or submits a Run. The equivalent MCP tool is `aiwb_handoff_bridge`.
+
 Candidate publication is off by default. To let an overnight Run publish its merge-ready Candidate, review and add this project-owned policy:
 
 ```yaml

--- a/tools/agent-orchestrator/skills/intake-aiwb-goal/SKILL.md
+++ b/tools/agent-orchestrator/skills/intake-aiwb-goal/SKILL.md
@@ -31,6 +31,23 @@ aiwb goal intake --repo /path/to/project --contract /path/to/contract.yaml
 Pass the handoff to the shared interface. Do not reimplement schema validation,
 normalization, readiness blockers, or cheapest-path selection in this Skill.
 
+## Create the next safe artifact
+
+After planning intake, use the bridge only with an explicit reviewed policy and
+caller-selected output outside the target repository:
+
+```bash
+aiwb goal bridge --repo /path/to/project \
+  --handoff /path/to/handoff.json \
+  --policy /path/to/reviewed-policy.yaml \
+  --output /path/outside/project/next-artifact.yaml
+```
+
+The equivalent MCP tool is `aiwb_handoff_bridge`. A fully mapped handoff creates
+an unapproved Contract and side-effect-free preflight result. Missing approved
+command mappings or `allowed_paths` creates only a non-executable policy draft.
+Do not invent commands, paths, approvals, provider changes, or placeholders.
+
 ## Interpret
 
 - `interactive` / `interactive_matt`: use the installed `$ask-matt` router, or

--- a/tools/agent-orchestrator/src/aiwb/__init__.py
+++ b/tools/agent-orchestrator/src/aiwb/__init__.py
@@ -31,6 +31,7 @@ from .harness import (
     HarnessRequest,
     LocalProcessHarness,
 )
+from .handoff_bridge import GoalHandoffBridge, HandoffBridgeResult
 from .harness_setup import (
     HarnessApplyRequest,
     HarnessAssessment,
@@ -113,6 +114,7 @@ __all__ = [
     "DoctorCheck",
     "DoctorReport",
     "GoalRunner",
+    "GoalHandoffBridge",
     "GoalIntake",
     "GoalIntakeResult",
     "GateError",
@@ -126,6 +128,7 @@ __all__ = [
     "HarnessRequest",
     "HarnessSetup",
     "HarnessSetupRequest",
+    "HandoffBridgeResult",
     "HarnessVerification",
     "HarnessVerifyRequest",
     "ImageBuildError",

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -8,6 +8,7 @@ from typing import Optional, Sequence, Tuple
 
 from .agent import AgentRouter, ClaudeCodeCliAdapter, CodexCliAdapter
 from .daemon import AgentDaemon, DaemonClient, DaemonError
+from .handoff_bridge import GoalHandoffBridge
 from .harness_setup import (
     HarnessApplyRequest,
     HarnessSetup,
@@ -155,6 +156,12 @@ def _build_parser() -> argparse.ArgumentParser:
     draft.add_argument("--tickets", required=True, type=Path)
     draft.add_argument("--output", required=True, type=Path)
     draft.add_argument("--force", action="store_true")
+
+    bridge = goal_commands.add_parser("bridge")
+    bridge.add_argument("--repo", required=True, type=Path)
+    bridge.add_argument("--handoff", required=True, type=Path)
+    bridge.add_argument("--policy", required=True, type=Path)
+    bridge.add_argument("--output", required=True, type=Path)
 
     daemon = commands.add_parser("daemon")
     daemon_commands = daemon.add_subparsers(dest="daemon_command", required=True)
@@ -312,6 +319,15 @@ def _run_doctor(options: argparse.Namespace) -> int:
 
 
 def _run_goal(options: argparse.Namespace) -> int:
+    if options.goal_command == "bridge":
+        result = GoalHandoffBridge().create(
+            repository=options.repo,
+            handoff_path=options.handoff,
+            policy_path=options.policy,
+            output_path=options.output,
+        )
+        _print_json(result.to_dict())
+        return 0
     if options.goal_command == "draft":
         result = TicketContractDraftBuilder().create(
             tickets_path=options.tickets,

--- a/tools/agent-orchestrator/src/aiwb/handoff_bridge.py
+++ b/tools/agent-orchestrator/src/aiwb/handoff_bridge.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Mapping, Tuple
+
+import yaml
+
+from .intake import GoalIntake, IntakeBlocker
+from .project import ProjectPolicy
+from .runner import preview_execution
+
+
+@dataclass(frozen=True)
+class HandoffBridgeResult:
+    readiness: str
+    artifact_kind: str
+    artifact_path: str
+    blockers: Tuple[IntakeBlocker, ...]
+    warnings: Tuple[str, ...]
+    preflight: Mapping[str, object]
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "readiness": self.readiness,
+            "artifact_kind": self.artifact_kind,
+            "artifact_path": self.artifact_path,
+            "blockers": [asdict(blocker) for blocker in self.blockers],
+            "warnings": list(self.warnings),
+            "preflight": dict(self.preflight),
+        }
+
+
+class GoalHandoffBridge:
+    """Create the next safe artifact from a reviewed planning handoff."""
+
+    def create(
+        self,
+        *,
+        repository: Path,
+        handoff_path: Path,
+        policy_path: Path,
+        output_path: Path,
+    ) -> HandoffBridgeResult:
+        repository = Path(repository).expanduser().resolve()
+        handoff_path = Path(handoff_path).expanduser().resolve()
+        policy_path = Path(policy_path).expanduser().resolve()
+        output_path = Path(output_path).expanduser().resolve()
+        _require_external_new_output(output_path, repository)
+
+        intake = GoalIntake().inspect(
+            repository=repository,
+            handoff_path=handoff_path,
+        )
+        normalized = intake.planning_handoff
+        if not normalized:
+            draft = _policy_draft_document(
+                repository=repository,
+                handoff={},
+                policy_path=policy_path,
+                blockers=intake.blockers,
+                warnings=intake.warnings,
+                policy={},
+            )
+            _write_yaml_atomically(output_path, draft)
+            return HandoffBridgeResult(
+                readiness="blocked",
+                artifact_kind="policy_draft",
+                artifact_path=str(output_path),
+                blockers=intake.blockers,
+                warnings=intake.warnings,
+                preflight={},
+            )
+        handoff_blockers = tuple(
+            blocker
+            for blocker in intake.blockers
+            if blocker.code in _HANDOFF_BLOCKER_CODES
+        )
+        policy_data = _read_mapping(policy_path, "reviewed policy")
+        policy_blockers = list(
+            _policy_review_blockers(
+                policy_data,
+                repository=repository,
+            )
+        )
+        command_definitions = _approved_command_definitions(policy_data)
+        policy = (
+            ProjectPolicy.load(policy_path)
+            if not policy_blockers
+            else None
+        )
+        contract, blockers, warnings = _contract_document(
+            repository=repository,
+            handoff=normalized,
+            policy=policy,
+            command_definitions=command_definitions,
+        )
+        blockers = _dedupe_blockers(
+            handoff_blockers + tuple(policy_blockers) + blockers
+        )
+        if blockers:
+            draft = _policy_draft_document(
+                repository=repository,
+                handoff=normalized,
+                policy_path=policy_path,
+                blockers=blockers,
+                warnings=warnings,
+                policy=policy_data,
+            )
+            _write_yaml_atomically(output_path, draft)
+            return HandoffBridgeResult(
+                readiness="blocked",
+                artifact_kind="policy_draft",
+                artifact_path=str(output_path),
+                blockers=blockers,
+                warnings=warnings,
+                preflight={},
+            )
+
+        temporary_path = _write_yaml_temporary(output_path, contract)
+        try:
+            preflight = preview_execution(
+                temporary_path,
+                workflow_path=policy_path,
+            ).to_dict()
+            temporary_path.replace(output_path)
+        except BaseException:
+            temporary_path.unlink(missing_ok=True)
+            raise
+        return HandoffBridgeResult(
+            readiness="ready_for_contract_approval",
+            artifact_kind="contract",
+            artifact_path=str(output_path),
+            blockers=(),
+            warnings=warnings,
+            preflight=preflight,
+        )
+
+
+def _contract_document(
+    *,
+    repository: Path,
+    handoff: Mapping[str, object],
+    policy: ProjectPolicy | None,
+    command_definitions: Mapping[str, Tuple[str, ...]],
+) -> Tuple[Mapping[str, object], Tuple[IntakeBlocker, ...], Tuple[str, ...]]:
+    goal = handoff.get("goal")
+    goal = goal if isinstance(goal, dict) else {}
+    acceptance = handoff.get("acceptance")
+    acceptance = acceptance if isinstance(acceptance, list) else []
+    todos = handoff.get("todos")
+    todos = todos if isinstance(todos, list) else []
+    blockers = []
+    warnings = []
+    contract_todos = []
+    for todo in todos:
+        if not isinstance(todo, dict):
+            continue
+        todo_id = str(todo.get("id", "unknown"))
+        command_name = todo.get("command_name")
+        command = (
+            command_definitions.get(command_name)
+            if isinstance(command_name, str)
+            else None
+        )
+        if (
+            command is None
+            or policy is None
+            or command not in policy.approved_commands
+        ):
+            blockers.append(
+                IntakeBlocker(
+                    code="approved_command_missing",
+                    message=f"Todo {todo_id} has no exact approved command mapping.",
+                    action=(
+                        "Add command_name referencing one approved policy "
+                        "capability, then rerun the bridge."
+                    ),
+                )
+            )
+        allowed_paths = todo.get("allowed_paths")
+        if (
+            not isinstance(allowed_paths, list)
+            or not allowed_paths
+            or not all(isinstance(item, str) and item for item in allowed_paths)
+        ):
+            blockers.append(
+                IntakeBlocker(
+                    code="allowed_paths_missing",
+                    message=f"Todo {todo_id} has no executable allowed_paths boundary.",
+                    action=(
+                        "Add non-empty allowed_paths for the Todo before "
+                        "creating an executable Contract."
+                    ),
+                )
+            )
+            warnings.append(
+                f"Todo {todo_id} needs reviewed allowed_paths before execution."
+            )
+        if command is None or not isinstance(allowed_paths, list) or not allowed_paths:
+            continue
+        contract_todos.append(
+            {
+                "id": todo_id,
+                "title": str(todo.get("title", todo_id)),
+                "depends_on": list(todo.get("depends_on", [])),
+                "test_ids": list(todo.get("acceptance_ids", [])),
+                "test": {
+                    "command": list(command),
+                    "allowed_paths": list(allowed_paths),
+                    "timeout_seconds": 600,
+                },
+            }
+        )
+    if not todos:
+        blockers.append(
+            IntakeBlocker(
+                code="todo_structure",
+                message="The planning handoff has no executable Todos.",
+                action="Add reviewed Todo structure before creating a Contract.",
+            )
+        )
+    provenance = handoff.get("provenance")
+    provenance = provenance if isinstance(provenance, dict) else {}
+    return (
+        {
+            "schema_version": 1,
+            "draft": {
+                "source_provenance": dict(provenance),
+                "source_handoff_kind": handoff.get("kind", ""),
+                "review_required": [
+                    "Review every command and allowed path against the source handoff.",
+                    "Review the fixed provider, resource decision, and non-production policy.",
+                    "Approve the Contract only after the acceptance boundary is complete.",
+                ],
+            },
+            "goal": {
+                "id": str(goal.get("id", "handoff-goal")),
+                "title": str(goal.get("title", "Planning handoff")),
+                "requirement": str(goal.get("requirement", "")),
+                "acceptance": acceptance,
+            },
+            "approval": {
+                "status": "draft",
+                "approved_by": "",
+                "approved_at": "",
+            },
+            "agent": {"provider": "codex"},
+            "project": {"repo": str(repository), "base_ref": "main"},
+            "resources": {},
+            "todos": contract_todos,
+        },
+        _dedupe_blockers(tuple(blockers)),
+        tuple(dict.fromkeys(warnings)),
+    )
+
+
+def _approved_command_definitions(
+    policy: Mapping[str, object],
+) -> Mapping[str, Tuple[str, ...]]:
+    capabilities = policy.get("capabilities")
+    capabilities = capabilities if isinstance(capabilities, dict) else {}
+    commands = capabilities.get("commands")
+    commands = commands if isinstance(commands, dict) else {}
+    return {
+        str(name): tuple(definition["argv"])
+        for name, definition in commands.items()
+        if isinstance(name, str)
+        and isinstance(definition, dict)
+        and definition.get("approved") is True
+        and isinstance(definition.get("argv"), list)
+        and all(isinstance(item, str) and item for item in definition["argv"])
+    }
+
+
+def _policy_draft_document(
+    *,
+    repository: Path,
+    handoff: Mapping[str, object],
+    policy_path: Path,
+    blockers: Tuple[IntakeBlocker, ...],
+    warnings: Tuple[str, ...],
+    policy: Mapping[str, object],
+) -> Mapping[str, object]:
+    return {
+        "schema_version": 1,
+        "kind": "aiwb.workflow-policy-draft",
+        "status": "draft",
+        "executable": False,
+        "project": {"root": str(repository), "trusted": False},
+        "source": {
+            "handoff_provenance": dict(handoff.get("provenance", {})),
+            "input_policy": str(policy_path),
+        },
+        "candidate_commands": _candidate_command_definitions(policy),
+        "blockers": [asdict(blocker) for blocker in blockers],
+        "warnings": list(warnings),
+        "review_actions": [blocker.action for blocker in blockers],
+    }
+
+
+def _policy_review_blockers(
+    policy: Mapping[str, object],
+    *,
+    repository: Path,
+) -> Tuple[IntakeBlocker, ...]:
+    blockers = []
+    project = policy.get("project")
+    project = project if isinstance(project, dict) else {}
+    root = project.get("root")
+    root_matches = (
+        isinstance(root, str)
+        and bool(root)
+        and Path(root).expanduser().resolve() == repository
+    )
+    if (
+        policy.get("schema_version") != 1
+        or policy.get("status") != "approved"
+        or project.get("trusted") is not True
+        or not root_matches
+    ):
+        blockers.append(
+            IntakeBlocker(
+                code="policy_not_approved",
+                message=(
+                    "The supplied policy must be schema version 1, approved, "
+                    "trusted, and bound to the target repository."
+                ),
+                action=(
+                    "Review the draft policy, approve repository trust and "
+                    "capabilities, then rerun the bridge."
+                ),
+            )
+        )
+    if not _approved_command_definitions(policy):
+        blockers.append(
+            IntakeBlocker(
+                code="approved_command_missing",
+                message="The supplied policy has no approved command capabilities.",
+                action=(
+                    "Review and approve the exact command capabilities needed "
+                    "by the planning handoff."
+                ),
+            )
+        )
+    return tuple(blockers)
+
+
+def _candidate_command_definitions(
+    policy: Mapping[str, object],
+) -> Mapping[str, object]:
+    suggestions = policy.get("suggestions")
+    suggestions = suggestions if isinstance(suggestions, dict) else {}
+    commands = suggestions.get("commands")
+    if not isinstance(commands, dict):
+        return {}
+    return {
+        str(name): {
+            "argv": list(definition["argv"]),
+            "reason": definition.get("reason", ""),
+        }
+        for name, definition in commands.items()
+        if isinstance(name, str)
+        and isinstance(definition, dict)
+        and isinstance(definition.get("argv"), list)
+        and all(isinstance(item, str) and item for item in definition["argv"])
+        and isinstance(definition.get("reason", ""), str)
+    }
+
+
+def _require_external_new_output(path: Path, repository: Path) -> None:
+    try:
+        path.relative_to(repository)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("bridge output must stay outside the target repository")
+    if path.exists():
+        raise ValueError(f"bridge output already exists: {path}")
+
+
+def _read_mapping(path: Path, label: str) -> Mapping[str, object]:
+    try:
+        value = yaml.safe_load(path.read_bytes())
+    except (OSError, yaml.YAMLError) as error:
+        raise ValueError(f"cannot read {label}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a mapping")
+    return value
+
+
+def _write_yaml_atomically(path: Path, value: Mapping[str, object]) -> None:
+    temporary_path = _write_yaml_temporary(path, value)
+    temporary_path.replace(path)
+
+
+def _write_yaml_temporary(path: Path, value: Mapping[str, object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            yaml.safe_dump(value, output, sort_keys=False)
+        return temporary_path
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def _dedupe_blockers(
+    blockers: Tuple[IntakeBlocker, ...],
+) -> Tuple[IntakeBlocker, ...]:
+    return tuple(
+        {
+            (blocker.code, blocker.message, blocker.action): blocker
+            for blocker in blockers
+        }.values()
+    )
+
+
+_HANDOFF_BLOCKER_CODES = frozenset(
+    {
+        "acceptance_boundary",
+        "handoff_provenance",
+        "handoff_validation",
+        "todo_dependencies",
+        "unsupported_handoff_schema",
+    }
+)

--- a/tools/agent-orchestrator/src/aiwb/mcp_server.py
+++ b/tools/agent-orchestrator/src/aiwb/mcp_server.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import IO, Dict, Mapping, Optional, Sequence
 
 from .daemon import DaemonClient, DaemonError
+from .handoff_bridge import GoalHandoffBridge
 from .intake import GoalIntake
 from .runner import preview_execution
 
@@ -91,6 +92,15 @@ class McpServer:
                     "socket": str(self._socket_path),
                     "status": "ok" if self._client.ping() else "unavailable",
                 }
+            elif name == "aiwb_handoff_bridge":
+                value = GoalHandoffBridge().create(
+                    repository=Path(_string_argument(arguments, "repository")),
+                    handoff_path=Path(
+                        _string_argument(arguments, "handoff_path")
+                    ),
+                    policy_path=Path(_string_argument(arguments, "policy_path")),
+                    output_path=Path(_string_argument(arguments, "output_path")),
+                ).to_dict()
             elif name == "aiwb_goal_preflight":
                 contract_path = _string_argument(arguments, "contract_path")
                 workflow_path = arguments.get("workflow_path")
@@ -206,6 +216,29 @@ def _tools():
                     "artifact_id": string_argument,
                 },
                 "required": ["run_id", "artifact_id"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "aiwb_handoff_bridge",
+            "description": (
+                "Create an external unapproved Contract or non-executable "
+                "policy draft from a planning handoff and reviewed policy."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repository": string_argument,
+                    "handoff_path": string_argument,
+                    "policy_path": string_argument,
+                    "output_path": string_argument,
+                },
+                "required": [
+                    "repository",
+                    "handoff_path",
+                    "policy_path",
+                    "output_path",
+                ],
                 "additionalProperties": False,
             },
         },

--- a/tools/agent-orchestrator/tests/test_goal_intake.py
+++ b/tools/agent-orchestrator/tests/test_goal_intake.py
@@ -8,13 +8,15 @@ import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
 import yaml
 
 
 TOOL_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(TOOL_ROOT / "src"))
 
-from aiwb import GoalIntake  # noqa: E402
+from aiwb import GoalHandoffBridge, GoalIntake  # noqa: E402
+from aiwb.cli import main as cli_main  # noqa: E402
 from aiwb.mcp_server import McpServer  # noqa: E402
 
 
@@ -310,6 +312,592 @@ def test_multi_todo_planning_handoff_preserves_source_and_planning_boundaries() 
         assert result.warnings == ()
         assert {item.code for item in result.blockers} == {"contract_draft"}
         assert result.execution_envelope["layers"] == [["T-1"], ["T-2"]]
+
+
+def test_handoff_bridge_writes_an_unapproved_preflighted_contract_outside_repo() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {
+                        "system": "github",
+                        "repository": "blackfaced/ai-workbench",
+                        "issue": 16,
+                    },
+                    "goal": {
+                        "id": "goal-16",
+                        "title": "Bridge planning handoffs",
+                        "requirement": "Create a safe next artifact.",
+                        "acceptance": [
+                            {
+                                "id": "AC-1",
+                                "statement": "The Contract remains unapproved.",
+                            }
+                        ],
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "Create the bridge",
+                            "depends_on": [],
+                            "acceptance_ids": ["AC-1"],
+                            "command_name": "unit",
+                            "allowed_paths": ["tests/test_bridge.py"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        policy = root / "reviewed-policy.yaml"
+        policy.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "status": "approved",
+                    "project": {"root": str(repository), "trusted": True},
+                    "capabilities": {
+                        "commands": {
+                            "unit": {
+                                "argv": [sys.executable, "-m", "pytest", "-q"],
+                                "approved": True,
+                            }
+                        },
+                        "skills": {},
+                    },
+                    "harness": {"profiles": {}},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        output = root / "artifacts" / "goal-16.contract.yaml"
+        before = _tree(repository)
+
+        result = GoalHandoffBridge().create(
+            repository=repository,
+            handoff_path=handoff,
+            policy_path=policy,
+            output_path=output,
+        )
+
+        assert result.readiness == "ready_for_contract_approval"
+        assert result.artifact_kind == "contract"
+        assert result.artifact_path == str(output.resolve())
+        assert result.blockers == ()
+        assert result.warnings == ()
+        contract = yaml.safe_load(output.read_text(encoding="utf-8"))
+        assert contract["approval"] == {
+            "status": "draft",
+            "approved_by": "",
+            "approved_at": "",
+        }
+        assert contract["todos"][0]["test"] == {
+            "command": [sys.executable, "-m", "pytest", "-q"],
+            "allowed_paths": ["tests/test_bridge.py"],
+            "timeout_seconds": 600,
+        }
+        assert contract["draft"]["source_provenance"]["issue"] == 16
+        assert result.preflight["readiness"] == "ready"
+        assert result.preflight["approval_status"] == "draft"
+        assert _tree(repository) == before
+
+
+def test_handoff_bridge_blocks_without_command_or_paths_and_writes_policy_draft() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {
+                        "system": "github",
+                        "repository": "blackfaced/ai-workbench",
+                        "issue": 16,
+                    },
+                    "goal": {
+                        "id": "goal-16",
+                        "title": "Bridge planning handoffs",
+                        "requirement": "Create a safe next artifact.",
+                        "acceptance": [
+                            {
+                                "id": "AC-1",
+                                "statement": "Missing execution data blocks.",
+                            }
+                        ],
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "Create the bridge",
+                            "depends_on": [],
+                            "acceptance_ids": ["AC-1"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        policy = root / "reviewed-policy.yaml"
+        policy.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "status": "approved",
+                    "project": {"root": str(repository), "trusted": True},
+                    "capabilities": {
+                        "commands": {
+                            "unit": {
+                                "argv": [sys.executable, "-m", "pytest", "-q"],
+                                "approved": True,
+                            }
+                        },
+                        "skills": {},
+                    },
+                    "harness": {"profiles": {}},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        output = root / "artifacts" / "workflow-draft.yaml"
+        before = _tree(repository)
+
+        result = GoalHandoffBridge().create(
+            repository=repository,
+            handoff_path=handoff,
+            policy_path=policy,
+            output_path=output,
+        )
+
+        assert result.readiness == "blocked"
+        assert result.artifact_kind == "policy_draft"
+        assert result.preflight == {}
+        assert {blocker.code for blocker in result.blockers} == {
+            "approved_command_missing",
+            "allowed_paths_missing",
+        }
+        assert result.warnings == (
+            "Todo T-1 needs reviewed allowed_paths before execution.",
+        )
+        draft = yaml.safe_load(output.read_text(encoding="utf-8"))
+        assert draft["kind"] == "aiwb.workflow-policy-draft"
+        assert draft["status"] == "draft"
+        assert draft["executable"] is False
+        assert draft["project"]["trusted"] is False
+        assert draft["source"]["handoff_provenance"]["issue"] == 16
+        assert len(draft["review_actions"]) == 2
+        serialized = output.read_text(encoding="utf-8")
+        assert "REPLACE_WITH" not in serialized
+        assert "todos:" not in serialized
+        assert _tree(repository) == before
+
+
+def test_handoff_bridge_turns_unapproved_policy_into_actionable_draft() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {"system": "test", "id": "unapproved-policy"},
+                    "goal": {
+                        "id": "policy-goal",
+                        "title": "Review policy",
+                        "requirement": "Keep policy review explicit.",
+                        "acceptance": [
+                            {"id": "AC-1", "statement": "Policy stays unapproved."}
+                        ],
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "Review",
+                            "depends_on": [],
+                            "acceptance_ids": ["AC-1"],
+                            "command_name": "unit",
+                            "allowed_paths": ["tests/test_policy.py"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        policy = root / "draft-policy.yaml"
+        policy.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "status": "draft",
+                    "project": {"root": str(repository), "trusted": False},
+                    "suggestions": {
+                        "commands": {
+                            "unit": {
+                                "argv": [sys.executable, "-m", "pytest", "-q"],
+                                "reason": "pytest detected",
+                            }
+                        }
+                    },
+                    "capabilities": {"commands": {}, "skills": {}},
+                    "harness": {"profiles": {}},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        output = root / "policy-review.yaml"
+
+        result = GoalHandoffBridge().create(
+            repository=repository,
+            handoff_path=handoff,
+            policy_path=policy,
+            output_path=output,
+        )
+
+        assert result.readiness == "blocked"
+        assert result.artifact_kind == "policy_draft"
+        assert {blocker.code for blocker in result.blockers} == {
+            "policy_not_approved",
+            "approved_command_missing",
+        }
+        draft = yaml.safe_load(output.read_text(encoding="utf-8"))
+        assert draft["candidate_commands"] == {
+            "unit": {
+                "argv": [sys.executable, "-m", "pytest", "-q"],
+                "reason": "pytest detected",
+            }
+        }
+        assert "candidate_policy" not in draft
+        assert draft["executable"] is False
+
+
+def test_handoff_bridge_writes_validation_failures_to_the_requested_artifact() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "unsupported-handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 99,
+                    "kind": "aiwb.planning-handoff",
+                    "goal": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        policy = root / "policy.yaml"
+        policy.write_text("not: inspected\n", encoding="utf-8")
+        output = root / "validation-result.yaml"
+
+        result = GoalHandoffBridge().create(
+            repository=repository,
+            handoff_path=handoff,
+            policy_path=policy,
+            output_path=output,
+        )
+
+        assert result.readiness == "blocked"
+        assert result.artifact_kind == "policy_draft"
+        assert result.artifact_path == str(output.resolve())
+        assert [blocker.code for blocker in result.blockers] == [
+            "unsupported_handoff_schema"
+        ]
+        draft = yaml.safe_load(output.read_text(encoding="utf-8"))
+        assert draft["kind"] == "aiwb.workflow-policy-draft"
+        assert draft["executable"] is False
+        assert draft["source"]["input_policy"] == str(policy.resolve())
+        assert draft["blockers"][0]["code"] == "unsupported_handoff_schema"
+
+
+def test_handoff_bridge_preserves_handoff_validation_blockers() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "incomplete-handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {},
+                    "goal": {
+                        "id": "incomplete",
+                        "title": "Incomplete",
+                        "requirement": "Do not create an executable Contract.",
+                        "acceptance": [],
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "Incomplete",
+                            "depends_on": ["missing"],
+                            "acceptance_ids": [],
+                            "command_name": "unit",
+                            "allowed_paths": ["tests/test_incomplete.py"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        policy = root / "policy.yaml"
+        policy.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "status": "approved",
+                    "project": {"root": str(repository), "trusted": True},
+                    "capabilities": {
+                        "commands": {
+                            "unit": {
+                                "argv": [sys.executable, "-m", "pytest", "-q"],
+                                "approved": True,
+                            }
+                        },
+                        "skills": {},
+                    },
+                    "harness": {"profiles": {}},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        output = root / "incomplete-result.yaml"
+
+        result = GoalHandoffBridge().create(
+            repository=repository,
+            handoff_path=handoff,
+            policy_path=policy,
+            output_path=output,
+        )
+
+        assert result.artifact_kind == "policy_draft"
+        assert {blocker.code for blocker in result.blockers} >= {
+            "handoff_provenance",
+            "todo_dependencies",
+            "acceptance_boundary",
+        }
+        assert yaml.safe_load(output.read_text(encoding="utf-8"))["executable"] is False
+
+
+def test_handoff_bridge_rejects_output_inside_repository_before_writing() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "handoff.json"
+        handoff.write_text("{}", encoding="utf-8")
+        policy = root / "policy.yaml"
+        policy.write_text("{}", encoding="utf-8")
+        output = repository / "bridge.yaml"
+
+        with pytest.raises(ValueError, match="outside"):
+            GoalHandoffBridge().create(
+                repository=repository,
+                handoff_path=handoff,
+                policy_path=policy,
+                output_path=output,
+            )
+
+        assert not output.exists()
+
+
+def test_handoff_bridge_leaves_no_contract_when_preflight_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {"system": "test", "id": "atomic"},
+                    "goal": {
+                        "id": "atomic-goal",
+                        "title": "Atomic bridge",
+                        "requirement": "Do not leave partial artifacts.",
+                        "acceptance": [
+                            {"id": "AC-1", "statement": "No partial artifact."}
+                        ],
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "Bridge",
+                            "depends_on": [],
+                            "acceptance_ids": ["AC-1"],
+                            "command_name": "unit",
+                            "allowed_paths": ["tests/test_bridge.py"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        policy = root / "policy.yaml"
+        policy.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "status": "approved",
+                    "project": {"root": str(repository), "trusted": True},
+                    "capabilities": {
+                        "commands": {
+                            "unit": {
+                                "argv": [sys.executable, "-m", "pytest", "-q"],
+                                "approved": True,
+                            }
+                        },
+                        "skills": {},
+                    },
+                    "harness": {"profiles": {}},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        output = root / "contract.yaml"
+
+        monkeypatch.setattr(
+            "aiwb.handoff_bridge.preview_execution",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                RuntimeError("simulated preflight failure")
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="simulated preflight"):
+            GoalHandoffBridge().create(
+                repository=repository,
+                handoff_path=handoff,
+                policy_path=policy,
+                output_path=output,
+            )
+
+        assert not output.exists()
+        assert not list(root.glob(".contract.yaml.*.tmp"))
+
+
+def test_cli_mcp_and_skill_share_handoff_bridge_semantics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _create_repository(root)
+        handoff = root / "handoff.json"
+        handoff.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "aiwb.planning-handoff",
+                    "provenance": {
+                        "system": "github",
+                        "repository": "blackfaced/ai-workbench",
+                        "issue": 16,
+                    },
+                    "goal": {
+                        "id": "goal-16",
+                        "title": "Bridge planning handoffs",
+                        "requirement": "Create a safe next artifact.",
+                        "acceptance": [
+                            {"id": "AC-1", "statement": "The bridge is safe."}
+                        ],
+                    },
+                    "todos": [
+                        {
+                            "id": "T-1",
+                            "title": "Create the bridge",
+                            "depends_on": [],
+                            "acceptance_ids": ["AC-1"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        policy = root / "reviewed-policy.yaml"
+        policy.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 1,
+                    "status": "approved",
+                    "project": {"root": str(repository), "trusted": True},
+                    "capabilities": {
+                        "commands": {
+                            "unit": {
+                                "argv": [sys.executable, "-m", "pytest", "-q"],
+                                "approved": True,
+                            }
+                        },
+                        "skills": {},
+                    },
+                    "harness": {"profiles": {}},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        cli_output = root / "cli-policy-draft.yaml"
+        mcp_output = root / "mcp-policy-draft.yaml"
+
+        returncode = cli_main(
+            [
+                "goal",
+                "bridge",
+                "--repo",
+                str(repository),
+                "--handoff",
+                str(handoff),
+                "--policy",
+                str(policy),
+                "--output",
+                str(cli_output),
+            ]
+        )
+        cli_value = json.loads(capsys.readouterr().out)
+        mcp_result = McpServer(root / "missing.sock")._call_tool(
+            "aiwb_handoff_bridge",
+            {
+                "repository": str(repository),
+                "handoff_path": str(handoff),
+                "policy_path": str(policy),
+                "output_path": str(mcp_output),
+            },
+        )
+        mcp_value = json.loads(mcp_result["content"][0]["text"])
+
+        assert returncode == 0
+        assert mcp_result["isError"] is False
+        assert cli_value["artifact_path"] == str(cli_output.resolve())
+        assert mcp_value["artifact_path"] == str(mcp_output.resolve())
+        assert {
+            key: value
+            for key, value in cli_value.items()
+            if key != "artifact_path"
+        } == {
+            key: value
+            for key, value in mcp_value.items()
+            if key != "artifact_path"
+        }
+        skill = (
+            TOOL_ROOT / "skills" / "intake-aiwb-goal" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        assert "aiwb goal bridge" in skill
+        assert "aiwb_handoff_bridge" in skill
+        assert "Do not invent" in skill
 
 
 def test_bare_issue_json_is_normalized_without_inventing_planning_details() -> None:

--- a/tools/agent-orchestrator/tests/test_mcp_server.py
+++ b/tools/agent-orchestrator/tests/test_mcp_server.py
@@ -111,6 +111,7 @@ def test_stdio_mcp_lists_tools_and_reports_daemon_status() -> None:
             assert [tool["name"] for tool in listed["result"]["tools"]] == [
                 "aiwb_daemon_status",
                 "aiwb_goal_evidence",
+                "aiwb_handoff_bridge",
                 "aiwb_goal_intake",
                 "aiwb_goal_preflight",
                 "aiwb_goal_report",


### PR DESCRIPTION
## Summary
- bridge explicit planning handoff command names and allowed paths to reviewed policy capabilities
- atomically emit either an unapproved preflighted Contract or a non-executable policy draft outside the target repository
- expose equivalent CLI, MCP, and intake Skill semantics with structured blockers and no invented commands or paths

## Test plan
- `PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m pytest -q` -> 145 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m compileall -q src tests`
- `diff -q .codex/skills/intake-aiwb-goal/SKILL.md tools/agent-orchestrator/skills/intake-aiwb-goal/SKILL.md`
- `git diff --check origin/main...HEAD`

Closes #16