### PR TITLE
feat: apply approved Python L0 Harness plans

### DIFF
--- a/.codex/skills/setup-ai-workbench/SKILL.md
+++ b/.codex/skills/setup-ai-workbench/SKILL.md
@@ -57,6 +57,21 @@ aiwb setup --repo /path/to/repository --planning-mode python-l0 \
 Plan Approval is durable planning state only. It does not authorize Apply,
 execute probes, or create a Candidate.
 
+## Apply an approved Python L0 Plan
+
+Apply requires a second exact approval. Use the approved Plan artifact, a full
+base commit SHA, an external state directory, and explicit `--apply-command`
+selections. Run `--preview-apply`, review every file digest, dependency,
+canonical command, side effect, branch, and worktree, then record
+`--approve-apply` to an external `--apply-artifact`. Execute only with
+`--execute-apply` and the unchanged arguments.
+
+Do not substitute Plan Approval for Apply Approval. Do not select `adopt` or
+`migrate_later` commands before the owner approves their dependencies and
+migration. Apply writes only an isolated candidate worktree, never the primary
+working tree or target branch. Preserve a failed candidate and its report for
+review. `configured_local` is not pipeline verification.
+
 ## Confirm before applying
 
 If the user wants a project-local draft workflow, state exactly what will be

--- a/tools/agent-orchestrator/README.md
+++ b/tools/agent-orchestrator/README.md
@@ -48,6 +48,35 @@ aiwb setup --repo /path/to/repository --planning-mode python-l0 \
 
 Plan Approval does not authorize Apply, run probes, or create a Candidate.
 
+Python L0 Apply uses a separate exact approval envelope. First preview the
+candidate files, dependencies, canonical commands, side effects, base commit,
+branch, and worktree:
+
+```bash
+aiwb setup --repo /path/to/repository --planning-mode python-l0 \
+  --approved-plan /path/to/approved-plan.json \
+  --base-commit <full-commit-sha> --state-dir /path/to/state \
+  --apply-command unit --preview-apply
+```
+
+Record exact Apply Approval outside the target repository:
+
+```bash
+aiwb setup --repo /path/to/repository --planning-mode python-l0 \
+  --approved-plan /path/to/approved-plan.json \
+  --base-commit <full-commit-sha> --state-dir /path/to/state \
+  --apply-command unit --approve-apply --approved-by owner \
+  --apply-artifact /path/to/approved-apply.json
+```
+
+Then execute that unchanged envelope with `--execute-apply` and the same
+arguments. Apply creates and commits only an isolated candidate branch/worktree,
+generates one consistent policy/guide/Codex Skill/Claude Skill/pipeline draft,
+runs only approved project-owned probes, and writes reports under the external
+state directory. Local success is `configured_local`, never `verified`. Failure
+preserves the candidate, first-failure Evidence, report, and cleanup status; the
+target branch and dirty primary working tree remain untouched.
+
 `GoalRunner.run(contract)` is the execution interface and test surface. It hides Contract validation, checkpoint persistence, Git worktree management, RED/GREEN machine gates, role prompts, Evidence capture, and recovery.
 
 `DaemonClient.submit/status/report/evidence` is the control interface. It hides the Unix socket protocol, background queue, SQLite job state, thread pool, stale socket handling, content-addressed Evidence retrieval, and process-restart recovery.

--- a/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
+++ b/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
@@ -57,6 +57,21 @@ aiwb setup --repo /path/to/repository --planning-mode python-l0 \
 Plan Approval is durable planning state only. It does not authorize Apply,
 execute probes, or create a Candidate.
 
+## Apply an approved Python L0 Plan
+
+Apply requires a second exact approval. Use the approved Plan artifact, a full
+base commit SHA, an external state directory, and explicit `--apply-command`
+selections. Run `--preview-apply`, review every file digest, dependency,
+canonical command, side effect, branch, and worktree, then record
+`--approve-apply` to an external `--apply-artifact`. Execute only with
+`--execute-apply` and the unchanged arguments.
+
+Do not substitute Plan Approval for Apply Approval. Do not select `adopt` or
+`migrate_later` commands before the owner approves their dependencies and
+migration. Apply writes only an isolated candidate worktree, never the primary
+working tree or target branch. Preserve a failed candidate and its report for
+review. `configured_local` is not pipeline verification.
+
 ## Confirm before applying
 
 If the user wants a project-local draft workflow, state exactly what will be

--- a/tools/agent-orchestrator/src/aiwb/__init__.py
+++ b/tools/agent-orchestrator/src/aiwb/__init__.py
@@ -31,6 +31,14 @@ from .harness import (
     HarnessRequest,
     LocalProcessHarness,
 )
+from ._harness_apply import (
+    HarnessApplyApproval,
+    HarnessApplyPreview,
+    HarnessApplyResult,
+    HarnessFileProjection,
+    HarnessProbeCommand,
+    HarnessProbeEvidence,
+)
 from .handoff_bridge import GoalHandoffBridge, HandoffBridgeResult
 from ._python_setup import CodeStructureEvidence, ExternalAnalysisEvidence
 from .harness_setup import (
@@ -124,9 +132,15 @@ __all__ = [
     "HarnessError",
     "HarnessExecution",
     "HarnessApplyRequest",
+    "HarnessApplyApproval",
+    "HarnessApplyPreview",
+    "HarnessApplyResult",
     "HarnessAssessment",
     "HarnessCandidate",
     "HarnessPlan",
+    "HarnessFileProjection",
+    "HarnessProbeCommand",
+    "HarnessProbeEvidence",
     "HarnessProfile",
     "HarnessRequest",
     "HarnessSetup",

--- a/tools/agent-orchestrator/src/aiwb/_harness_apply.py
+++ b/tools/agent-orchestrator/src/aiwb/_harness_apply.py
@@ -1,0 +1,869 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Tuple
+
+import yaml
+
+from .evidence import EvidenceReference, EvidenceStore
+
+if TYPE_CHECKING:
+    from .harness_setup import HarnessPlan
+
+
+@dataclass(frozen=True)
+class HarnessFileProjection:
+    path: str
+    content: str
+    executable: bool = False
+    previous_sha256: str = ""
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "path": self.path,
+            "content": self.content,
+            "executable": self.executable,
+            "previous_sha256": self.previous_sha256,
+            "sha256": hashlib.sha256(self.content.encode("utf-8")).hexdigest(),
+        }
+
+
+@dataclass(frozen=True)
+class HarnessProbeCommand:
+    name: str
+    argv: Tuple[str, ...]
+    source_argv: Tuple[str, ...]
+    working_directory: str
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "name": self.name,
+            "argv": list(self.argv),
+            "source_argv": list(self.source_argv),
+            "working_directory": self.working_directory,
+        }
+
+
+@dataclass(frozen=True)
+class HarnessApplyPreview:
+    state: str
+    repository: str
+    plan_digest: str
+    base_commit: str
+    state_dir: str
+    branch: str
+    worktree: str
+    files: Tuple[HarnessFileProjection, ...]
+    dependencies: Tuple[str, ...]
+    commands: Tuple[HarnessProbeCommand, ...]
+    side_effects: Tuple[str, ...]
+    digest: str
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "state": self.state,
+            "repository": self.repository,
+            "plan_digest": self.plan_digest,
+            "base_commit": self.base_commit,
+            "state_dir": self.state_dir,
+            "branch": self.branch,
+            "worktree": self.worktree,
+            "files": [item.to_dict() for item in self.files],
+            "dependencies": list(self.dependencies),
+            "commands": [item.to_dict() for item in self.commands],
+            "side_effects": list(self.side_effects),
+            "digest": self.digest,
+        }
+
+
+@dataclass(frozen=True)
+class HarnessApplyApproval:
+    status: str
+    approved_by: str
+    approved_at: str
+    artifact_path: str
+    preview: HarnessApplyPreview
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "status": self.status,
+            "approved_by": self.approved_by,
+            "approved_at": self.approved_at,
+            "artifact_path": self.artifact_path,
+            "preview": self.preview.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class HarnessProbeEvidence:
+    name: str
+    command: Tuple[str, ...]
+    working_directory: str
+    returncode: int
+    stdout: str
+    stderr: str
+    recorded_at: str
+    duration_seconds: float
+    artifacts: Tuple[str, ...] = ()
+    stdout_ref: Optional[EvidenceReference] = None
+    stderr_ref: Optional[EvidenceReference] = None
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "name": self.name,
+            "command": list(self.command),
+            "working_directory": self.working_directory,
+            "returncode": self.returncode,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "recorded_at": self.recorded_at,
+            "duration_seconds": self.duration_seconds,
+            "artifacts": list(self.artifacts),
+            "stdout_ref": _reference_dict(self.stdout_ref),
+            "stderr_ref": _reference_dict(self.stderr_ref),
+        }
+
+
+@dataclass(frozen=True)
+class HarnessApplyResult:
+    status: str
+    changed: bool
+    repository: str
+    branch: str
+    worktree: str
+    base_commit: str
+    candidate_commit: str
+    evidence: Tuple[HarnessProbeEvidence, ...]
+    consumption: Mapping[str, object]
+    report_path: str
+    cleanup_status: str
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "status": self.status,
+            "changed": self.changed,
+            "repository": self.repository,
+            "branch": self.branch,
+            "worktree": self.worktree,
+            "base_commit": self.base_commit,
+            "candidate_commit": self.candidate_commit,
+            "evidence": [item.to_dict() for item in self.evidence],
+            "consumption": dict(self.consumption),
+            "report_path": self.report_path,
+            "cleanup_status": self.cleanup_status,
+        }
+
+
+def preview_python_l0_apply(
+    plan: "HarnessPlan",
+    *,
+    base_commit: str,
+    state_dir: Path,
+    command_names: Sequence[str],
+) -> HarnessApplyPreview:
+    if plan.approval.status != "approved":
+        raise ValueError("Apply preview requires an approved Harness Plan")
+    if plan.request.planning_mode != "python-l0":
+        raise ValueError("Apply preview requires a Python L0 Harness Plan")
+    repository = Path(plan.request.repository).expanduser().resolve()
+    state_dir = Path(state_dir).expanduser().resolve()
+    try:
+        state_dir.relative_to(repository)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("Apply state directory must stay outside the target repository")
+    base_commit = _resolve_commit(repository, base_commit)
+    selected = _select_commands(plan, command_names)
+    files, commands = _render_projections(repository, base_commit, selected)
+    side_effects = (
+        "create candidate branch from the explicit base commit",
+        "create isolated candidate worktree under the selected state directory",
+        "write and commit the exact approved projection files",
+        "execute only the selected project-owned local probe commands",
+        "retain the candidate worktree and external report on success or failure",
+        "do not modify or merge the target branch",
+    )
+    plan_digest = _digest(plan.to_dict())
+    intent = {
+        "repository": str(repository),
+        "plan_digest": plan_digest,
+        "base_commit": base_commit,
+        "state_dir": str(state_dir),
+        "files": [item.to_dict() for item in files],
+        "dependencies": [],
+        "commands": [item.to_dict() for item in commands],
+        "side_effects": list(side_effects),
+    }
+    digest = _digest(intent)
+    branch = f"aiwb/harness-setup/{base_commit[:8]}-{digest[:10]}"
+    worktree = state_dir / "worktrees" / "harness-setup" / digest[:16]
+    return HarnessApplyPreview(
+        state="awaiting_apply_approval",
+        repository=str(repository),
+        plan_digest=plan_digest,
+        base_commit=base_commit,
+        state_dir=str(state_dir),
+        branch=branch,
+        worktree=str(worktree),
+        files=files,
+        dependencies=(),
+        commands=commands,
+        side_effects=side_effects,
+        digest=digest,
+    )
+
+
+def approve_python_l0_apply(
+    preview: HarnessApplyPreview,
+    *,
+    approved_by: str,
+    artifact_path: Path,
+    approved_at: Optional[datetime] = None,
+) -> HarnessApplyApproval:
+    if preview.state != "awaiting_apply_approval":
+        raise ValueError("Apply Approval requires an awaiting_apply_approval preview")
+    if not approved_by.strip():
+        raise ValueError("Apply Approval requires an approver")
+    _validate_preview_digest(preview)
+    artifact_path = Path(artifact_path).expanduser().resolve()
+    repository = Path(preview.repository)
+    try:
+        artifact_path.relative_to(repository)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("Apply Approval artifact must stay outside the target repository")
+    if artifact_path.exists():
+        raise ValueError(f"Apply Approval artifact already exists: {artifact_path}")
+    approved_at = approved_at or datetime.now(timezone.utc)
+    approval = HarnessApplyApproval(
+        status="approved",
+        approved_by=approved_by.strip(),
+        approved_at=approved_at.astimezone(timezone.utc).isoformat(),
+        artifact_path=str(artifact_path),
+        preview=preview,
+    )
+    _write_json_atomically(artifact_path, approval.to_dict())
+    return approval
+
+
+def load_python_l0_apply_approval(
+    preview: HarnessApplyPreview,
+    artifact_path: Path,
+) -> HarnessApplyApproval:
+    artifact_path = Path(artifact_path).expanduser().resolve()
+    data = _read_json_mapping(artifact_path, "Apply Approval")
+    approval = HarnessApplyApproval(
+        status=str(data.get("status", "")),
+        approved_by=str(data.get("approved_by", "")),
+        approved_at=str(data.get("approved_at", "")),
+        artifact_path=str(data.get("artifact_path", "")),
+        preview=preview,
+    )
+    if approval.status != "approved":
+        raise ValueError("Apply Approval artifact is not approved")
+    if approval.artifact_path != str(artifact_path):
+        raise ValueError("Apply Approval artifact path does not match its content")
+    if approval.to_dict() != data:
+        raise ValueError("Apply Approval artifact does not match the current exact preview")
+    _validate_preview_digest(preview)
+    return approval
+
+
+def apply_python_l0(
+    plan: "HarnessPlan",
+    approval: HarnessApplyApproval,
+    *,
+    state_dir: Path,
+) -> HarnessApplyResult:
+    if plan.approval.status != "approved":
+        raise ValueError("Candidate Apply requires an approved Harness Plan")
+    if approval.status != "approved":
+        raise ValueError("Candidate Apply requires exact Apply Approval")
+    preview = approval.preview
+    _validate_preview_digest(preview)
+    if preview.plan_digest != _digest(plan.to_dict()):
+        raise ValueError("Apply Approval does not match the approved Harness Plan")
+    state_dir = Path(state_dir).expanduser().resolve()
+    if str(state_dir) != preview.state_dir:
+        raise ValueError("Apply state directory does not match the approved preview")
+    repository = Path(preview.repository)
+    worktree = Path(preview.worktree)
+    _ensure_candidate_worktree(
+        repository=repository,
+        worktree=worktree,
+        branch=preview.branch,
+        base_commit=preview.base_commit,
+        files=preview.files,
+    )
+    changed = _write_projections(worktree, preview.files)
+    if changed:
+        _git(worktree, "add", "-A")
+        _git(
+            worktree,
+            "commit",
+            "-m",
+            "chore: configure Python L0 Harness",
+            "-m",
+            "Co-authored-by: TRAE CLI <noreply@bytedance.com>",
+        )
+    candidate_commit = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+    evidence = []
+    evidence_store = EvidenceStore(state_dir)
+    started = time.monotonic()
+    for command in preview.commands:
+        command_started = time.monotonic()
+        completed = subprocess.run(
+            list(command.argv),
+            cwd=str(worktree),
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=600,
+        )
+        stdout, stdout_ref = evidence_store.retain_text(
+            completed.stdout,
+            label=f"harness-setup/{preview.digest}/{command.name}/stdout",
+        )
+        stderr, stderr_ref = evidence_store.retain_text(
+            completed.stderr,
+            label=f"harness-setup/{preview.digest}/{command.name}/stderr",
+        )
+        evidence.append(
+            HarnessProbeEvidence(
+                name=command.name,
+                command=command.argv,
+                working_directory=".",
+                returncode=completed.returncode,
+                stdout=stdout,
+                stderr=stderr,
+                recorded_at=_now(),
+                duration_seconds=time.monotonic() - command_started,
+                artifacts=_retain_probe_artifacts(
+                    worktree,
+                    state_dir,
+                    preview.digest,
+                    command.name,
+                ),
+                stdout_ref=stdout_ref,
+                stderr_ref=stderr_ref,
+            )
+        )
+        if completed.returncode != 0:
+            break
+    status = (
+        "configured_local"
+        if evidence and all(item.returncode == 0 for item in evidence)
+        else "failed_local"
+    )
+    consumption = {
+        "probe_executions": len(evidence),
+        "probe_seconds": time.monotonic() - started,
+    }
+    report_path = (
+        state_dir
+        / "reports"
+        / "harness-setup"
+        / preview.digest
+        / "report.json"
+    )
+    result = HarnessApplyResult(
+        status=status,
+        changed=changed,
+        repository=str(repository),
+        branch=preview.branch,
+        worktree=str(worktree),
+        base_commit=preview.base_commit,
+        candidate_commit=candidate_commit,
+        evidence=tuple(evidence),
+        consumption=consumption,
+        report_path=str(report_path),
+        cleanup_status="not_required",
+    )
+    _write_json_atomically(report_path, result.to_dict())
+    return result
+
+
+def _select_commands(
+    plan: "HarnessPlan",
+    command_names: Sequence[str],
+) -> Tuple[object, ...]:
+    if not command_names:
+        raise ValueError("Apply preview requires at least one canonical command")
+    selected = []
+    for requested in command_names:
+        matches = tuple(
+            candidate
+            for candidate in plan.command_candidates
+            if candidate.name == requested
+            or candidate.name.rsplit(":", 1)[-1] == requested
+        )
+        if len(matches) != 1:
+            raise ValueError(
+                f"canonical command name must resolve exactly once: {requested}"
+            )
+        candidate = matches[0]
+        disposition = _candidate_disposition(plan, candidate.name)
+        if disposition not in {"keep", "augment"}:
+            raise ValueError(
+                f"canonical command is not locally configured: {candidate.name}"
+            )
+        selected.append(candidate)
+    return tuple(selected)
+
+
+def _candidate_disposition(plan: "HarnessPlan", name: str) -> str:
+    target_path, separator, capability_name = name.rpartition(":")
+    if not separator:
+        target_path = "."
+        capability_name = name
+    profile = plan.assessment.project_profile
+    if profile is None:
+        return ""
+    for target in profile.targets:
+        if target.path != target_path:
+            continue
+        for capability in target.capabilities:
+            if capability.name == capability_name:
+                return capability.disposition
+    return ""
+
+
+def _render_projections(
+    repository: Path,
+    base_commit: str,
+    selected: Sequence[object],
+) -> Tuple[Tuple[HarnessFileProjection, ...], Tuple[HarnessProbeCommand, ...]]:
+    wrappers = []
+    probe_commands = []
+    approved_commands = {}
+    canonical_lines = []
+    pipeline_lines = []
+    for candidate in selected:
+        safe_name = _safe_name(candidate.name)
+        source_argv = tuple(candidate.argv)
+        if safe_name == "unit" and "pytest" in source_argv:
+            source_argv = source_argv + ("-s", "--junitxml=junit.xml")
+        wrapper_path = f".ai-workbench/commands/{safe_name}.sh"
+        wrapper = _wrapper_content(
+            working_directory=candidate.working_directory,
+            argv=source_argv,
+        )
+        wrappers.append(
+            HarnessFileProjection(
+                path=wrapper_path,
+                content=wrapper,
+                executable=True,
+            )
+        )
+        canonical = ("bash", wrapper_path)
+        approved_commands[safe_name] = {
+            "argv": list(canonical),
+            "approved": True,
+        }
+        probe_commands.append(
+            HarnessProbeCommand(
+                name=safe_name,
+                argv=canonical,
+                source_argv=source_argv,
+                working_directory=candidate.working_directory,
+            )
+        )
+        rendered = shlex.join(canonical)
+        canonical_lines.append(f"- `{rendered}`")
+        pipeline_lines.append(f"      - run: {rendered}")
+    workflow = {
+        "schema_version": 1,
+        "status": "approved",
+        "project": {"root": str(repository), "trusted": True},
+        "capabilities": {"commands": approved_commands, "skills": {}},
+        "harness": {"allowed_kubernetes_contexts": [], "profiles": {}},
+        "images": {"profiles": {}},
+    }
+    guide = (
+        "# Project Harness\n\n"
+        "Run only the project-owned canonical commands:\n\n"
+        + "\n".join(canonical_lines)
+        + "\n\nLocal success means `configured_local`, not pipeline verification.\n"
+    )
+    skill = (
+        "---\n"
+        "name: project-harness\n"
+        "description: Run the project-owned local Harness commands.\n"
+        "---\n\n"
+        "# Project Harness\n\n"
+        + "\n".join(canonical_lines)
+        + "\n\nDo not substitute global commands or production environments.\n"
+    )
+    pipeline = (
+        "name: AI Workbench Harness\n"
+        "on:\n"
+        "  push:\n"
+        "  pull_request:\n"
+        "jobs:\n"
+        "  harness:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2\n"
+        + "\n".join(pipeline_lines)
+        + "\n"
+    )
+    self_test = (
+        "from pathlib import Path\n\n"
+        "def test_harness_projection_is_consistent():\n"
+        "    root = Path(__file__).resolve().parents[2]\n"
+        "    workflow = (root / '.ai-workbench/workflow.yaml').read_text()\n"
+        "    guide = (root / 'docs/engineering/harness.md').read_text()\n"
+        "    pipeline = (root / '.github/workflows/aiwb-harness.yml').read_text()\n"
+        f"    commands = {list(shlex.join(item.argv) for item in probe_commands)!r}\n"
+        "    for command in commands:\n"
+        "        assert command in guide\n"
+        "        assert command in pipeline\n"
+        "        assert command.split()[-1] in workflow\n"
+    )
+    files = (
+        HarnessFileProjection(
+            path=".ai-workbench/workflow.yaml",
+            content=yaml.safe_dump(workflow, sort_keys=False),
+        ),
+        *wrappers,
+        HarnessFileProjection(
+            path=".github/workflows/aiwb-harness.yml",
+            content=pipeline,
+        ),
+        HarnessFileProjection(
+            path=".codex/skills/project-harness/SKILL.md",
+            content=skill,
+        ),
+        HarnessFileProjection(
+            path=".claude/skills/project-harness/SKILL.md",
+            content=skill,
+        ),
+        HarnessFileProjection(
+            path="docs/engineering/harness.md",
+            content=guide,
+        ),
+        HarnessFileProjection(
+            path="tests/aiwb/test_harness_projection.py",
+            content=self_test,
+        ),
+    )
+    return (
+        tuple(
+            replace(
+                projection,
+                previous_sha256=_base_file_digest(
+                    repository,
+                    base_commit,
+                    projection.path,
+                ),
+            )
+            for projection in files
+        ),
+        tuple(probe_commands),
+    )
+
+
+def _wrapper_content(
+    *,
+    working_directory: str,
+    argv: Sequence[str],
+) -> str:
+    lines = ["#!/usr/bin/env bash", "set -euo pipefail", 'root="$(git rev-parse --show-toplevel)"']
+    if working_directory == ".":
+        lines.append('cd "$root"')
+    else:
+        lines.append(f'cd "$root"/{shlex.quote(working_directory)}')
+    lines.append(f"exec {shlex.join(tuple(argv))}")
+    return "\n".join(lines) + "\n"
+
+
+def _retain_probe_artifacts(
+    worktree: Path,
+    state_dir: Path,
+    preview_digest: str,
+    command_name: str,
+) -> Tuple[str, ...]:
+    names = {
+        "unit": ("junit.xml",),
+        "coverage": ("coverage.xml",),
+    }.get(command_name, ())
+    retained = []
+    for name in names:
+        source = worktree / name
+        if not source.is_file():
+            continue
+        destination = (
+            state_dir
+            / "reports"
+            / "harness-setup"
+            / preview_digest
+            / "artifacts"
+            / command_name
+            / name
+        )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        _write_bytes_atomically(destination, source.read_bytes())
+        source.unlink()
+        retained.append(str(destination))
+    return tuple(retained)
+
+
+def _base_file_digest(repository: Path, commit: str, path: str) -> str:
+    completed = subprocess.run(
+        ["git", "show", f"{commit}:{path}"],
+        cwd=str(repository),
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        return ""
+    return hashlib.sha256(completed.stdout).hexdigest()
+
+
+def _reference_dict(
+    reference: Optional[EvidenceReference],
+) -> Optional[Mapping[str, object]]:
+    if reference is None:
+        return None
+    return {
+        "artifact_id": reference.artifact_id,
+        "sha256": reference.sha256,
+        "size_bytes": reference.size_bytes,
+        "media_type": reference.media_type,
+        "label": reference.label,
+    }
+
+
+def _ensure_candidate_worktree(
+    *,
+    repository: Path,
+    worktree: Path,
+    branch: str,
+    base_commit: str,
+    files: Sequence[HarnessFileProjection],
+) -> None:
+    if (worktree / ".git").exists():
+        actual_branch = _git(worktree, "branch", "--show-current").stdout.strip()
+        if actual_branch != branch:
+            raise ValueError("existing candidate worktree is on an unexpected branch")
+        head = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+        if head != base_commit and not _candidate_matches_approved_projection(
+            worktree,
+            base_commit,
+            files,
+        ):
+            raise ValueError(
+                "existing candidate worktree is not at the approved base commit "
+                "or exact approved projection"
+            )
+        if _git(worktree, "status", "--porcelain").stdout:
+            raise ValueError("existing candidate worktree must be clean")
+        return
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    branch_exists = (
+        _git(
+            repository,
+            "show-ref",
+            "--verify",
+            "--quiet",
+            f"refs/heads/{branch}",
+            check=False,
+        ).returncode
+        == 0
+    )
+    if branch_exists:
+        branch_head = _git(repository, "rev-parse", branch).stdout.strip()
+        if branch_head != base_commit:
+            raise ValueError(
+                "existing candidate branch is not at the approved base commit"
+            )
+        _git(repository, "worktree", "add", str(worktree), branch)
+    else:
+        _git(
+            repository,
+            "worktree",
+            "add",
+            "-b",
+            branch,
+            str(worktree),
+            base_commit,
+        )
+
+
+def _write_projections(
+    worktree: Path,
+    files: Sequence[HarnessFileProjection],
+) -> bool:
+    _validate_projection_destinations(worktree, files)
+    changed = False
+    for projection in files:
+        relative = Path(projection.path)
+        destination = worktree / relative
+        encoded = projection.content.encode("utf-8")
+        if destination.is_file() and destination.read_bytes() == encoded:
+            if projection.executable:
+                destination.chmod(destination.stat().st_mode | 0o100)
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        _write_bytes_atomically(destination, encoded)
+        if projection.executable:
+            destination.chmod(0o755)
+        changed = True
+    return changed
+
+
+def _validate_projection_destinations(
+    worktree: Path,
+    files: Sequence[HarnessFileProjection],
+) -> None:
+    for projection in files:
+        relative = Path(projection.path)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError(
+                f"projection path must stay inside the candidate: {projection.path}"
+            )
+        destination = worktree / projection.path
+        try:
+            destination.resolve().relative_to(worktree.resolve())
+        except ValueError as error:
+            raise ValueError(
+                f"projection path must stay inside the candidate: {projection.path}"
+            ) from error
+
+
+def _candidate_matches_approved_projection(
+    worktree: Path,
+    base_commit: str,
+    files: Sequence[HarnessFileProjection],
+) -> bool:
+    try:
+        _validate_projection_destinations(worktree, files)
+    except ValueError:
+        return False
+    changed = {
+        path
+        for path in _git(
+            worktree,
+            "diff",
+            "--name-only",
+            f"{base_commit}..HEAD",
+        ).stdout.splitlines()
+        if path
+    }
+    if changed != {projection.path for projection in files}:
+        return False
+    for projection in files:
+        destination = worktree / projection.path
+        if not destination.is_file():
+            return False
+        if destination.read_text(encoding="utf-8") != projection.content:
+            return False
+    return True
+
+
+def _validate_preview_digest(preview: HarnessApplyPreview) -> None:
+    intent = {
+        "repository": preview.repository,
+        "plan_digest": preview.plan_digest,
+        "base_commit": preview.base_commit,
+        "state_dir": preview.state_dir,
+        "files": [item.to_dict() for item in preview.files],
+        "dependencies": list(preview.dependencies),
+        "commands": [item.to_dict() for item in preview.commands],
+        "side_effects": list(preview.side_effects),
+    }
+    if preview.digest != _digest(intent):
+        raise ValueError("Apply preview digest does not match its exact envelope")
+
+
+def _resolve_commit(repository: Path, value: str) -> str:
+    if not value:
+        raise ValueError("Apply preview requires an explicit base commit")
+    resolved = _git(
+        repository,
+        "rev-parse",
+        "--verify",
+        f"{value}^{{commit}}",
+        check=False,
+    )
+    if resolved.returncode != 0:
+        raise ValueError(f"base commit is not available: {value}")
+    commit = resolved.stdout.strip()
+    if value != commit:
+        raise ValueError("base commit must be an explicit full commit hash")
+    return commit
+
+
+def _safe_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "command"
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _git(
+    cwd: Path,
+    *arguments: str,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=str(cwd),
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _write_json_atomically(path: Path, value: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    _write_bytes_atomically(path, encoded)
+
+
+def _read_json_mapping(path: Path, label: str) -> Mapping[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read {label}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _write_bytes_atomically(path: Path, content: bytes) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(content)
+        temporary.replace(path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -86,6 +86,15 @@ def _build_parser() -> argparse.ArgumentParser:
     setup.add_argument("--approve-plan", action="store_true")
     setup.add_argument("--approved-by")
     setup.add_argument("--plan-artifact", type=Path)
+    setup.add_argument("--approved-plan", type=Path)
+    apply_operation = setup.add_mutually_exclusive_group()
+    apply_operation.add_argument("--preview-apply", action="store_true")
+    apply_operation.add_argument("--approve-apply", action="store_true")
+    apply_operation.add_argument("--execute-apply", action="store_true")
+    setup.add_argument("--base-commit")
+    setup.add_argument("--state-dir", type=Path)
+    setup.add_argument("--apply-command", action="append", default=[])
+    setup.add_argument("--apply-artifact", type=Path)
     setup.add_argument("--apply", action="store_true")
 
     skills = commands.add_parser("skills")
@@ -264,6 +273,60 @@ def _run_setup(options: argparse.Namespace) -> int:
             raise ValueError(
                 "planning mode is read-only and cannot be combined with --apply"
             )
+        apply_requested = (
+            options.preview_apply
+            or options.approve_apply
+            or options.execute_apply
+        )
+        if apply_requested:
+            if (
+                options.approved_plan is None
+                or not options.base_commit
+                or options.state_dir is None
+                or not options.apply_command
+            ):
+                raise ValueError(
+                    "Harness Apply requires --approved-plan, --base-commit, "
+                    "--state-dir, and at least one --apply-command"
+                )
+            approved_plan = setup.load_approved_plan(
+                plan,
+                options.approved_plan,
+            )
+            preview = setup.preview_apply(
+                approved_plan,
+                base_commit=options.base_commit,
+                state_dir=options.state_dir,
+                command_names=tuple(options.apply_command),
+            )
+            if options.preview_apply:
+                _print_json(preview.to_dict())
+                return 0
+            if options.apply_artifact is None:
+                raise ValueError(
+                    "Apply Approval and execution require --apply-artifact"
+                )
+            if options.approve_apply:
+                if not options.approved_by:
+                    raise ValueError("Apply Approval requires --approved-by")
+                approval = setup.approve_apply(
+                    preview,
+                    approved_by=options.approved_by,
+                    artifact_path=options.apply_artifact,
+                )
+                _print_json(approval.to_dict())
+                return 0
+            approval = setup.load_apply_approval(
+                preview,
+                options.apply_artifact,
+            )
+            result = setup.apply_approved(
+                approved_plan,
+                approval,
+                state_dir=options.state_dir,
+            )
+            _print_json(result.to_dict())
+            return 0
         if options.approve_plan:
             if not options.approved_by or options.plan_artifact is None:
                 raise ValueError(
@@ -278,9 +341,31 @@ def _run_setup(options: argparse.Namespace) -> int:
             raise ValueError(
                 "--approved-by and --plan-artifact require --approve-plan"
             )
+        elif (
+            options.approved_plan is not None
+            or options.base_commit
+            or options.state_dir is not None
+            or options.apply_command
+            or options.apply_artifact is not None
+        ):
+            raise ValueError(
+                "Harness Apply arguments require an Apply operation"
+            )
         _print_json(plan.to_dict())
         return 0
-    if options.approve_plan or options.approved_by or options.plan_artifact is not None:
+    if (
+        options.approve_plan
+        or options.approved_by
+        or options.plan_artifact is not None
+        or options.approved_plan is not None
+        or options.preview_apply
+        or options.approve_apply
+        or options.execute_apply
+        or options.base_commit
+        or options.state_dir is not None
+        or options.apply_command
+        or options.apply_artifact is not None
+    ):
         raise ValueError("Plan Approval requires --planning-mode")
     role_skills = _role_skills(options.role_skill)
     pack_skills = _pack_skills(options.install_pack, options.pack_skill)

--- a/tools/agent-orchestrator/src/aiwb/harness_setup.py
+++ b/tools/agent-orchestrator/src/aiwb/harness_setup.py
@@ -4,7 +4,7 @@ import json
 import os
 import subprocess
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Mapping, Optional, Sequence, Tuple
@@ -17,6 +17,15 @@ from ._python_setup import (
     ProjectProfile,
     inspect_python_l0,
     planning_from_profile,
+)
+from ._harness_apply import (
+    HarnessApplyApproval,
+    HarnessApplyPreview,
+    HarnessApplyResult,
+    apply_python_l0,
+    approve_python_l0_apply,
+    load_python_l0_apply_approval,
+    preview_python_l0_apply,
 )
 from .project import DoctorReport, ProjectDoctor, ProjectInitializer
 from .skills import (
@@ -305,6 +314,88 @@ class HarnessSetup:
         )
         _write_json_atomically(artifact_path, approved.to_dict())
         return approved
+
+    def load_approved_plan(
+        self,
+        plan: HarnessPlan,
+        artifact_path: Path,
+    ) -> HarnessPlan:
+        artifact_path = Path(artifact_path).expanduser().resolve()
+        try:
+            data = json.loads(artifact_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError(f"cannot read Plan Approval: {error}") from error
+        if not isinstance(data, dict):
+            raise ValueError("Plan Approval must be a JSON object")
+        approval_data = data.get("approval")
+        if not isinstance(approval_data, dict):
+            raise ValueError("Plan Approval is missing approval metadata")
+        approved = replace(
+            plan,
+            approval=PlanApproval(
+                status=str(approval_data.get("status", "")),
+                approved_by=str(approval_data.get("approved_by", "")),
+                approved_at=str(approval_data.get("approved_at", "")),
+                artifact_path=str(approval_data.get("artifact_path", "")),
+            ),
+        )
+        if approved.approval.status != "approved":
+            raise ValueError("Plan Approval artifact is not approved")
+        if approved.approval.artifact_path != str(artifact_path):
+            raise ValueError("Plan Approval artifact path does not match its content")
+        if approved.to_dict() != data:
+            raise ValueError("Plan Approval artifact does not match the current Plan")
+        return approved
+
+    def preview_apply(
+        self,
+        plan: HarnessPlan,
+        *,
+        base_commit: str,
+        state_dir: Path,
+        command_names: Sequence[str],
+    ) -> HarnessApplyPreview:
+        return preview_python_l0_apply(
+            plan,
+            base_commit=base_commit,
+            state_dir=state_dir,
+            command_names=command_names,
+        )
+
+    def approve_apply(
+        self,
+        preview: HarnessApplyPreview,
+        *,
+        approved_by: str,
+        artifact_path: Path,
+        approved_at: Optional[datetime] = None,
+    ) -> HarnessApplyApproval:
+        return approve_python_l0_apply(
+            preview,
+            approved_by=approved_by,
+            artifact_path=artifact_path,
+            approved_at=approved_at,
+        )
+
+    def load_apply_approval(
+        self,
+        preview: HarnessApplyPreview,
+        artifact_path: Path,
+    ) -> HarnessApplyApproval:
+        return load_python_l0_apply_approval(preview, artifact_path)
+
+    def apply_approved(
+        self,
+        plan: HarnessPlan,
+        approval: HarnessApplyApproval,
+        *,
+        state_dir: Path,
+    ) -> HarnessApplyResult:
+        return apply_python_l0(
+            plan,
+            approval,
+            state_dir=state_dir,
+        )
 
     def apply(self, request: HarnessApplyRequest) -> HarnessCandidate:
         if request.plan.state != "planned":

--- a/tools/agent-orchestrator/tests/test_harness_apply.py
+++ b/tools/agent-orchestrator/tests/test_harness_apply.py
@@ -1,0 +1,861 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+TOOL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOL_ROOT / "src"))
+
+from aiwb import EvidenceStore, HarnessSetup, HarnessSetupRequest  # noqa: E402
+from aiwb.cli import main as cli_main  # noqa: E402
+
+
+def test_approved_python_l0_apply_configures_isolated_candidate() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        primary_branch = _git(repository, "branch", "--show-current").stdout.strip()
+        dirty = repository / "owner-notes.txt"
+        dirty.write_text("keep me\n", encoding="utf-8")
+        primary_before = _git(repository, "status", "--porcelain").stdout
+        state_dir = root / "state"
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            approved_at=datetime(2026, 7, 28, tzinfo=timezone.utc),
+            artifact_path=root / "approved-plan.json",
+        )
+
+        preview = setup.preview_apply(
+            approved_plan,
+            base_commit=base_commit,
+            state_dir=state_dir,
+            command_names=("unit",),
+        )
+
+        assert preview.state == "awaiting_apply_approval"
+        assert preview.base_commit == base_commit
+        assert preview.dependencies == ()
+        assert preview.commands[0].name == "unit"
+        assert preview.commands[0].argv == (
+            "bash",
+            ".ai-workbench/commands/unit.sh",
+        )
+        assert {
+            projection.path for projection in preview.files
+        } >= {
+            ".ai-workbench/workflow.yaml",
+            ".ai-workbench/commands/unit.sh",
+            ".github/workflows/aiwb-harness.yml",
+            ".codex/skills/project-harness/SKILL.md",
+            ".claude/skills/project-harness/SKILL.md",
+            "docs/engineering/harness.md",
+            "tests/aiwb/test_harness_projection.py",
+        }
+        assert "create candidate branch" in " ".join(preview.side_effects)
+
+        approval = setup.approve_apply(
+            preview,
+            approved_by="owner",
+            approved_at=datetime(2026, 7, 28, tzinfo=timezone.utc),
+            artifact_path=root / "approved-apply.json",
+        )
+        result = setup.apply_approved(
+            approved_plan,
+            approval,
+            state_dir=state_dir,
+        )
+
+        assert result.status == "configured_local"
+        assert result.changed is True
+        assert result.base_commit == base_commit
+        assert result.candidate_commit
+        assert result.candidate_commit != base_commit
+        assert result.branch.startswith("aiwb/harness-setup/")
+        worktree = Path(result.worktree)
+        assert worktree.is_dir()
+        assert all(evidence.returncode == 0 for evidence in result.evidence)
+        assert result.consumption["probe_executions"] == 1
+        assert result.consumption["probe_seconds"] >= 0
+        assert result.report_path
+        report = json.loads(Path(result.report_path).read_text(encoding="utf-8"))
+        assert report["status"] == "configured_local"
+        assert report["candidate_commit"] == result.candidate_commit
+
+        workflow = yaml.safe_load(
+            (worktree / ".ai-workbench" / "workflow.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        canonical = ["bash", ".ai-workbench/commands/unit.sh"]
+        assert workflow["capabilities"]["commands"]["unit"]["argv"] == canonical
+        pipeline = (
+            worktree / ".github" / "workflows" / "aiwb-harness.yml"
+        ).read_text(encoding="utf-8")
+        assert "bash .ai-workbench/commands/unit.sh" in pipeline
+        assert (
+            "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+            in pipeline
+        )
+        assert "actions/checkout@v4" not in pipeline
+        guide = (worktree / "docs" / "engineering" / "harness.md").read_text(
+            encoding="utf-8"
+        )
+        codex_skill = (
+            worktree / ".codex" / "skills" / "project-harness" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        claude_skill = (
+            worktree / ".claude" / "skills" / "project-harness" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        assert "bash .ai-workbench/commands/unit.sh" in guide
+        assert codex_skill == claude_skill
+        assert "bash .ai-workbench/commands/unit.sh" in codex_skill
+        generated = _git(
+            worktree,
+            "status",
+            "--porcelain",
+        ).stdout
+        assert generated == ""
+        self_test = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", "tests/aiwb/test_harness_projection.py"],
+            cwd=str(worktree),
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert self_test.returncode == 0, self_test.stderr or self_test.stdout
+
+        assert _git(repository, "branch", "--show-current").stdout.strip() == (
+            primary_branch
+        )
+        assert _git(repository, "rev-parse", "HEAD").stdout.strip() == base_commit
+        assert _git(repository, "status", "--porcelain").stdout == primary_before
+        assert dirty.read_text(encoding="utf-8") == "keep me\n"
+        assert _git(
+            repository,
+            "merge-base",
+            "--is-ancestor",
+            result.candidate_commit,
+            primary_branch,
+            check=False,
+        ).returncode != 0
+
+
+def test_apply_rejects_missing_or_modified_exact_approval_before_worktree() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        state_dir = root / "state"
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+        preview = setup.preview_apply(
+            approved_plan,
+            base_commit=base_commit,
+            state_dir=state_dir,
+            command_names=("unit",),
+        )
+
+        with pytest.raises(ValueError, match="exact Apply Approval"):
+            setup.apply_approved(
+                approved_plan,
+                replace(
+                    setup.approve_apply(
+                        preview,
+                        approved_by="owner",
+                        artifact_path=root / "apply.json",
+                    ),
+                    status="draft",
+                ),
+                state_dir=state_dir,
+            )
+
+        modified_preview = replace(
+            preview,
+            side_effects=preview.side_effects + ("push an image",),
+        )
+        with pytest.raises(ValueError, match="digest"):
+            setup.approve_apply(
+                modified_preview,
+                approved_by="owner",
+                artifact_path=root / "modified-apply.json",
+            )
+
+        approval = setup.approve_apply(
+            preview,
+            approved_by="owner",
+            artifact_path=root / "valid-apply.json",
+        )
+        with pytest.raises(ValueError, match="state directory"):
+            setup.apply_approved(
+                approved_plan,
+                approval,
+                state_dir=root / "other-state",
+            )
+
+        unapproved_plan = replace(
+            approved_plan,
+            approval=replace(approved_plan.approval, status="unapproved"),
+        )
+        with pytest.raises(ValueError, match="approved Harness Plan"):
+            setup.apply_approved(
+                unapproved_plan,
+                approval,
+                state_dir=state_dir,
+            )
+
+        assert not Path(preview.worktree).exists()
+        assert _git(repository, "worktree", "list", "--porcelain").stdout.count(
+            "worktree "
+        ) == 1
+
+
+def test_failed_probe_preserves_candidate_first_failure_and_report() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root, failing=True)
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        state_dir = root / "state"
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+        preview = setup.preview_apply(
+            approved_plan,
+            base_commit=base_commit,
+            state_dir=state_dir,
+            command_names=("unit",),
+        )
+        approval = setup.approve_apply(
+            preview,
+            approved_by="owner",
+            artifact_path=root / "approved-apply.json",
+        )
+
+        result = setup.apply_approved(
+            approved_plan,
+            approval,
+            state_dir=state_dir,
+        )
+
+        assert result.status == "failed_local"
+        assert Path(result.worktree).is_dir()
+        assert result.candidate_commit
+        assert len(result.evidence) == 1
+        failure = result.evidence[0]
+        assert failure.returncode == 1
+        assert "expected failure" in failure.stdout
+        assert "assert False" in failure.stdout
+        assert result.cleanup_status == "not_required"
+        report = json.loads(Path(result.report_path).read_text(encoding="utf-8"))
+        assert report["status"] == "failed_local"
+        assert report["evidence"][0]["returncode"] == 1
+        assert _git(
+            repository,
+            "show-ref",
+            "--verify",
+            f"refs/heads/{result.branch}",
+        ).returncode == 0
+        assert _git(repository, "rev-parse", "main").stdout.strip() == base_commit
+
+
+def test_reapplying_the_same_approval_is_idempotent() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        state_dir = root / "state"
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+        preview = setup.preview_apply(
+            approved_plan,
+            base_commit=base_commit,
+            state_dir=state_dir,
+            command_names=("unit",),
+        )
+        approval = setup.approve_apply(
+            preview,
+            approved_by="owner",
+            artifact_path=root / "approved-apply.json",
+        )
+
+        first = setup.apply_approved(
+            approved_plan,
+            approval,
+            state_dir=state_dir,
+        )
+        second = setup.apply_approved(
+            approved_plan,
+            approval,
+            state_dir=state_dir,
+        )
+
+        assert first.status == second.status == "configured_local"
+        assert second.changed is False
+        assert second.candidate_commit == first.candidate_commit
+        assert _git(
+            Path(first.worktree),
+            "rev-list",
+            "--count",
+            f"{base_commit}..HEAD",
+        ).stdout.strip() == "1"
+
+
+def test_python_l0_apply_runs_approved_quality_and_report_probes() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root, full_l0=True)
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        state_dir = root / "state"
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+        preview = setup.preview_apply(
+            approved_plan,
+            base_commit=base_commit,
+            state_dir=state_dir,
+            command_names=("lint", "format", "typecheck", "unit", "coverage"),
+        )
+        approval = setup.approve_apply(
+            preview,
+            approved_by="owner",
+            artifact_path=root / "approved-apply.json",
+        )
+
+        result = setup.apply_approved(
+            approved_plan,
+            approval,
+            state_dir=state_dir,
+        )
+
+        assert result.status == "configured_local"
+        assert [item.name for item in result.evidence] == [
+            "lint",
+            "format",
+            "typecheck",
+            "unit",
+            "coverage",
+        ]
+        assert all(item.returncode == 0 for item in result.evidence)
+        assert result.consumption["probe_executions"] == 5
+        artifacts = {
+            Path(path).name
+            for item in result.evidence
+            for path in item.artifacts
+        }
+        assert artifacts >= {"coverage.xml", "junit.xml"}
+        worktree = Path(result.worktree)
+        assert not (worktree / "coverage.xml").exists()
+        assert not (worktree / "junit.xml").exists()
+        assert all(Path(path).is_file() for item in result.evidence for path in item.artifacts)
+
+
+def test_python_l0_cli_preserves_both_approval_boundaries(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        approved_plan = root / "approved-plan.json"
+        approved_apply = root / "approved-apply.json"
+        state_dir = root / "state"
+
+        assert cli_main(
+            [
+                "setup",
+                "--repo",
+                str(repository),
+                "--planning-mode",
+                "python-l0",
+                "--approve-plan",
+                "--approved-by",
+                "owner",
+                "--plan-artifact",
+                str(approved_plan),
+            ]
+        ) == 0
+        capsys.readouterr()
+
+        assert cli_main(
+            [
+                "setup",
+                "--repo",
+                str(repository),
+                "--planning-mode",
+                "python-l0",
+                "--approved-plan",
+                str(approved_plan),
+                "--base-commit",
+                base_commit,
+                "--state-dir",
+                str(state_dir),
+                "--apply-command",
+                "unit",
+                "--preview-apply",
+            ]
+        ) == 0
+        preview = json.loads(capsys.readouterr().out)
+        assert preview["state"] == "awaiting_apply_approval"
+        assert not approved_apply.exists()
+
+        assert cli_main(
+            [
+                "setup",
+                "--repo",
+                str(repository),
+                "--planning-mode",
+                "python-l0",
+                "--approved-plan",
+                str(approved_plan),
+                "--base-commit",
+                base_commit,
+                "--state-dir",
+                str(state_dir),
+                "--apply-command",
+                "unit",
+                "--approve-apply",
+                "--approved-by",
+                "owner",
+                "--apply-artifact",
+                str(approved_apply),
+            ]
+        ) == 0
+        approval = json.loads(capsys.readouterr().out)
+        assert approval["status"] == "approved"
+        assert approved_apply.is_file()
+
+        assert cli_main(
+            [
+                "setup",
+                "--repo",
+                str(repository),
+                "--planning-mode",
+                "python-l0",
+                "--approved-plan",
+                str(approved_plan),
+                "--base-commit",
+                base_commit,
+                "--state-dir",
+                str(state_dir),
+                "--apply-command",
+                "unit",
+                "--execute-apply",
+                "--apply-artifact",
+                str(approved_apply),
+            ]
+        ) == 0
+        result = json.loads(capsys.readouterr().out)
+        assert result["status"] == "configured_local"
+        assert Path(result["worktree"]).is_dir()
+
+
+def test_apply_preview_records_existing_file_digest_for_exact_review() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        existing = repository / "docs" / "engineering" / "harness.md"
+        existing.parent.mkdir(parents=True)
+        existing.write_text("# Existing owner guide\n", encoding="utf-8")
+        _git(repository, "add", ".")
+        _git(repository, "commit", "-m", "Add owner guide")
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+
+        preview = setup.preview_apply(
+            approved_plan,
+            base_commit=base_commit,
+            state_dir=root / "state",
+            command_names=("unit",),
+        )
+
+        guide = next(
+            item
+            for item in preview.files
+            if item.path == "docs/engineering/harness.md"
+        )
+        assert guide.previous_sha256
+        assert guide.previous_sha256 != guide.to_dict()["sha256"]
+        workflow = next(
+            item
+            for item in preview.files
+            if item.path == ".ai-workbench/workflow.yaml"
+        )
+        assert workflow.previous_sha256 == ""
+
+
+def test_probe_output_is_bounded_and_full_evidence_is_retained() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root, noisy=True)
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        state_dir = root / "state"
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+        preview = setup.preview_apply(
+            approved_plan,
+            base_commit=base_commit,
+            state_dir=state_dir,
+            command_names=("unit",),
+        )
+        approval = setup.approve_apply(
+            preview,
+            approved_by="owner",
+            artifact_path=root / "approved-apply.json",
+        )
+
+        result = setup.apply_approved(
+            approved_plan,
+            approval,
+            state_dir=state_dir,
+        )
+
+        evidence = result.evidence[0]
+        assert len(evidence.stdout.encode("utf-8")) <= 4096
+        assert "truncated" in evidence.stdout
+        assert evidence.stdout_ref is not None
+        payload = EvidenceStore(state_dir).read(
+            evidence.stdout_ref.artifact_id,
+            reference=evidence.stdout_ref,
+        )
+        assert len(payload.content) > 100_000
+
+
+def test_apply_rejects_projection_symlink_escape_and_preserves_outside() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        outside = root / "outside"
+        outside.mkdir()
+        (repository / ".ai-workbench").symlink_to(
+            outside,
+            target_is_directory=True,
+        )
+        _git(repository, "add", ".")
+        _git(repository, "commit", "-m", "Add unsafe projection symlink")
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        state_dir = root / "state"
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+        preview = setup.preview_apply(
+            approved_plan,
+            base_commit=base_commit,
+            state_dir=state_dir,
+            command_names=("unit",),
+        )
+        approval = setup.approve_apply(
+            preview,
+            approved_by="owner",
+            artifact_path=root / "approved-apply.json",
+        )
+
+        with pytest.raises(ValueError, match="inside the candidate"):
+            setup.apply_approved(
+                approved_plan,
+                approval,
+                state_dir=state_dir,
+            )
+
+        assert list(outside.iterdir()) == []
+
+
+def test_apply_rejects_existing_candidate_at_unapproved_commit() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        state_dir = root / "state"
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+        preview = setup.preview_apply(
+            approved_plan,
+            base_commit=base_commit,
+            state_dir=state_dir,
+            command_names=("unit",),
+        )
+        approval = setup.approve_apply(
+            preview,
+            approved_by="owner",
+            artifact_path=root / "approved-apply.json",
+        )
+        worktree = Path(preview.worktree)
+        _git(
+            repository,
+            "worktree",
+            "add",
+            "-b",
+            preview.branch,
+            str(worktree),
+            base_commit,
+        )
+        unrelated = worktree / "unrelated.txt"
+        unrelated.write_text("not approved\n", encoding="utf-8")
+        _git(worktree, "add", ".")
+        _git(worktree, "commit", "-m", "Unapproved candidate mutation")
+
+        with pytest.raises(ValueError, match="approved base commit"):
+            setup.apply_approved(
+                approved_plan,
+                approval,
+                state_dir=state_dir,
+            )
+
+
+def test_apply_rejects_state_directory_inside_primary_repository() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+
+        with pytest.raises(ValueError, match="outside the target repository"):
+            setup.preview_apply(
+                approved_plan,
+                base_commit=base_commit,
+                state_dir=repository / ".ai-workbench-state",
+                command_names=("unit",),
+            )
+
+        assert not (repository / ".ai-workbench-state").exists()
+
+
+def test_apply_rejects_unmounted_candidate_branch_at_unapproved_commit() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        base_commit = _git(repository, "rev-parse", "HEAD").stdout.strip()
+        state_dir = root / "state"
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+        preview = setup.preview_apply(
+            approved_plan,
+            base_commit=base_commit,
+            state_dir=state_dir,
+            command_names=("unit",),
+        )
+        approval = setup.approve_apply(
+            preview,
+            approved_by="owner",
+            artifact_path=root / "approved-apply.json",
+        )
+        _git(repository, "branch", preview.branch, base_commit)
+        intruder = root / "intruder"
+        _git(repository, "worktree", "add", str(intruder), preview.branch)
+        (intruder / "unapproved.txt").write_text("unapproved\n", encoding="utf-8")
+        _git(intruder, "add", ".")
+        _git(intruder, "commit", "-m", "Unapproved branch mutation")
+        _git(repository, "worktree", "remove", str(intruder))
+
+        with pytest.raises(ValueError, match="approved base commit"):
+            setup.apply_approved(
+                approved_plan,
+                approval,
+                state_dir=state_dir,
+            )
+
+        assert not Path(preview.worktree).exists()
+
+
+def _python_repository(
+    root: Path,
+    failing: bool = False,
+    full_l0: bool = False,
+    noisy: bool = False,
+) -> Path:
+    repository = root / "project"
+    repository.mkdir()
+    _git(repository, "init", "-b", "main")
+    _git(repository, "config", "user.name", "AI Workbench Test")
+    _git(repository, "config", "user.email", "aiwb@example.test")
+    (repository / ".gitignore").write_text(
+        "__pycache__/\n*.pyc\n.pytest_cache/\n",
+        encoding="utf-8",
+    )
+    (repository / "tests").mkdir()
+    (repository / "tests" / "test_sample.py").write_text(
+        (
+            "def test_sample():\n"
+            "    print('expected failure')\n"
+            "    assert False\n"
+            if failing
+            else "def test_sample():\n"
+            "    print('x' * 120000)\n"
+            "    assert True\n"
+            if noisy
+            else "def test_sample():\n"
+            "    assert 1 + 1 == 2\n"
+        ),
+        encoding="utf-8",
+    )
+    if full_l0:
+        (repository / "ruff.py").write_text(
+            "import sys\n"
+            "raise SystemExit(0 if sys.argv[1] in {'check', 'format'} else 2)\n",
+            encoding="utf-8",
+        )
+        (repository / "mypy.py").write_text(
+            "raise SystemExit(0)\n",
+            encoding="utf-8",
+        )
+        (repository / "conftest.py").write_text(
+            "from pathlib import Path\n\n"
+            "def pytest_addoption(parser):\n"
+            "    parser.addoption('--cov', action='store', nargs='?', const='.')\n"
+            "    parser.addoption('--cov-report', action='store')\n\n"
+            "def pytest_sessionfinish(session, exitstatus):\n"
+            "    if session.config.getoption('--cov') is not None:\n"
+            "        Path('coverage.xml').write_text('<coverage/>\\n')\n",
+            encoding="utf-8",
+        )
+    dependencies = (
+        "test = ['pytest>=8', 'pytest-cov>=5', 'ruff==0.12.4', 'mypy==1.17']\n\n"
+        if full_l0
+        else "test = ['pytest>=8']\n\n"
+    )
+    (repository / "pyproject.toml").write_text(
+        "[build-system]\n"
+        "requires = ['setuptools>=68']\n"
+        "build-backend = 'setuptools.build_meta'\n\n"
+        "[project]\n"
+        "name = 'sample'\n\n"
+        "[project.optional-dependencies]\n"
+        + dependencies
+        +
+        "[tool.pytest.ini_options]\n"
+        "testpaths = ['tests']\n",
+        encoding="utf-8",
+    )
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "Initial fixture")
+    return repository
+
+
+def _git(
+    repository: Path,
+    *arguments: str,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=str(repository),
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )


### PR DESCRIPTION
## Summary
- add a separate exact Apply Approval envelope over approved Python L0 Harness Plans
- create deterministic candidate branches and isolated worktrees from full base commits without modifying or merging the primary branch
- generate consistent policy, canonical wrappers, engineering guide, Codex/Claude Skills, pinned pipeline draft, and projection self-test
- run only approved keep/augment probes with bounded Evidence, standard report retention, consumption, configured_local state, failure preservation, and idempotence

## Test plan
- `PYTHONPYCACHEPREFIX=/tmp/aiwb-issue21-final-full PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m pytest -q` -> 166 passed
- `PYTHONPYCACHEPREFIX=/tmp/aiwb-issue21-final-focused PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m pytest -q tests/test_harness_apply.py tests/test_harness_setup.py tests/test_workbench_setup.py tests/test_project_policy.py tests/test_skill_cli.py tests/test_mcp_server.py` -> 53 passed
- `PYTHONPYCACHEPREFIX=/tmp/aiwb-issue21-final-focused PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m compileall -q src tests`
- `diff -q .codex/skills/setup-ai-workbench/SKILL.md tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md`
- `git diff --check origin/main...HEAD`

The isolated `PYTHONPYCACHEPREFIX` is the documented workaround for existing issue #33.

Closes #21