### PR TITLE
feat: verify exact candidates with GitHub Actions

### DIFF
--- a/.codex/skills/setup-ai-workbench/SKILL.md
+++ b/.codex/skills/setup-ai-workbench/SKILL.md
@@ -72,6 +72,16 @@ migration. Apply writes only an isolated candidate worktree, never the primary
 working tree or target branch. Preserve a failed candidate and its report for
 review. `configured_local` is not pipeline verification.
 
+## Verify the exact candidate commit
+
+Once an approved repository flow publishes the configured candidate, use
+`aiwb pipeline verify` with the candidate report, GitHub owner/repository,
+required check names, required artifact names, and an external state directory.
+This is read-only against GitHub. Do not dispatch a workflow, inspect secret
+values, change required checks, or accept a green result for another commit.
+Report `pipeline_pending`, `verification_failed`, or `verified` exactly as
+returned, preserving first failures and explicit retries.
+
 ## Confirm before applying
 
 If the user wants a project-local draft workflow, state exactly what will be

--- a/.github/workflows/aiwb-harness.yml
+++ b/.github/workflows/aiwb-harness.yml
@@ -1,0 +1,57 @@
+name: AI Workbench Harness
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  harness:
+    name: harness
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: tools/agent-orchestrator
+    steps:
+      - name: Checkout exact commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: tools/agent-orchestrator/setup.cfg
+
+      - name: Install Harness dependencies
+        run: python -m pip install -e ".[test]"
+
+      - name: Run Harness
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+          PYTHONPYCACHEPREFIX: ${{ runner.temp }}/aiwb-pycache
+        run: python -m pytest -q --junitxml=junit.xml
+
+      - name: Record exact commit metadata
+        if: always()
+        run: |
+          mkdir -p artifacts
+          printf '%s\n' \
+            "commit=${GITHUB_SHA}" \
+            "run_id=${GITHUB_RUN_ID}" \
+            "run_attempt=${GITHUB_RUN_ATTEMPT}" \
+            > artifacts/pipeline-evidence.txt
+
+      - name: Upload Harness Evidence
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: harness-evidence
+          path: |
+            tools/agent-orchestrator/junit.xml
+            tools/agent-orchestrator/artifacts/pipeline-evidence.txt
+          if-no-files-found: error
+          retention-days: 14

--- a/tools/agent-orchestrator/README.md
+++ b/tools/agent-orchestrator/README.md
@@ -77,6 +77,33 @@ state directory. Local success is `configured_local`, never `verified`. Failure
 preserves the candidate, first-failure Evidence, report, and cleanup status; the
 target branch and dirty primary working tree remain untouched.
 
+## GitHub Pipeline Verification
+
+After a `configured_local` candidate commit is published by an approved
+repository flow, read its GitHub Actions state without dispatching a workflow:
+
+```bash
+aiwb pipeline verify \
+  --candidate-report /path/to/configured-local-report.json \
+  --owner owner --repository repository \
+  --required-check harness \
+  --required-artifact harness-evidence \
+  --state-dir /path/outside/repository/state
+```
+
+The Adapter uses only authenticated `gh api -X GET` requests for commit-scoped
+runs, jobs, checks, and artifact references. It never reads secret values,
+dispatches workflows, or changes repository settings. `configured_local`
+becomes `pipeline_pending`; only successful required checks and artifacts for
+the exact candidate commit can become `verified`. Stale green commits,
+failures, cancellation, missing or expired artifacts, and missing terminal
+checks remain explicitly non-verified. Every observed retry and first failure
+stays in the append-only external report.
+
+This repository dogfoods the Adapter through
+`.github/workflows/aiwb-harness.yml`. The workflow uses pinned Actions commits,
+the stable `harness` check name, and uploads `harness-evidence`.
+
 `GoalRunner.run(contract)` is the execution interface and test surface. It hides Contract validation, checkpoint persistence, Git worktree management, RED/GREEN machine gates, role prompts, Evidence capture, and recovery.
 
 `DaemonClient.submit/status/report/evidence` is the control interface. It hides the Unix socket protocol, background queue, SQLite job state, thread pool, stale socket handling, content-addressed Evidence retrieval, and process-restart recovery.

--- a/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
+++ b/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
@@ -72,6 +72,16 @@ migration. Apply writes only an isolated candidate worktree, never the primary
 working tree or target branch. Preserve a failed candidate and its report for
 review. `configured_local` is not pipeline verification.
 
+## Verify the exact candidate commit
+
+Once an approved repository flow publishes the configured candidate, use
+`aiwb pipeline verify` with the candidate report, GitHub owner/repository,
+required check names, required artifact names, and an external state directory.
+This is read-only against GitHub. Do not dispatch a workflow, inspect secret
+values, change required checks, or accept a green result for another commit.
+Report `pipeline_pending`, `verification_failed`, or `verified` exactly as
+returned, preserving first failures and explicit retries.
+
 ## Confirm before applying
 
 If the user wants a project-local draft workflow, state exactly what will be

--- a/tools/agent-orchestrator/src/aiwb/__init__.py
+++ b/tools/agent-orchestrator/src/aiwb/__init__.py
@@ -40,6 +40,13 @@ from ._harness_apply import (
     HarnessProbeEvidence,
 )
 from .handoff_bridge import GoalHandoffBridge, HandoffBridgeResult
+from .github_pipeline import (
+    GhApiGitHubSource,
+    GitHubActionsAdapter,
+    GitHubPipelineRequest,
+    PipelineEvidence,
+    PipelineVerification,
+)
 from ._python_setup import CodeStructureEvidence, ExternalAnalysisEvidence
 from .harness_setup import (
     HarnessApplyRequest,
@@ -128,6 +135,9 @@ __all__ = [
     "GoalHandoffBridge",
     "GoalIntake",
     "GoalIntakeResult",
+    "GhApiGitHubSource",
+    "GitHubActionsAdapter",
+    "GitHubPipelineRequest",
     "GateError",
     "HarnessError",
     "HarnessExecution",
@@ -163,6 +173,8 @@ __all__ = [
     "ProjectInitPreview",
     "ProjectInitResult",
     "ProjectPolicy",
+    "PipelineEvidence",
+    "PipelineVerification",
     "ProviderQuotaError",
     "ProjectConfigError",
     "ProjectDoctor",

--- a/tools/agent-orchestrator/src/aiwb/_harness_apply.py
+++ b/tools/agent-orchestrator/src/aiwb/_harness_apply.py
@@ -133,6 +133,32 @@ class HarnessProbeEvidence:
             "stderr_ref": _reference_dict(self.stderr_ref),
         }
 
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> "HarnessProbeEvidence":
+        command = value.get("command", [])
+        artifacts = value.get("artifacts", [])
+        if not isinstance(command, list) or not all(
+            isinstance(item, str) for item in command
+        ):
+            raise ValueError("Harness Evidence command must be a string list")
+        if not isinstance(artifacts, list) or not all(
+            isinstance(item, str) for item in artifacts
+        ):
+            raise ValueError("Harness Evidence artifacts must be a string list")
+        return cls(
+            name=str(value.get("name", "")),
+            command=tuple(command),
+            working_directory=str(value.get("working_directory", "")),
+            returncode=int(value.get("returncode", 0)),
+            stdout=str(value.get("stdout", "")),
+            stderr=str(value.get("stderr", "")),
+            recorded_at=str(value.get("recorded_at", "")),
+            duration_seconds=float(value.get("duration_seconds", 0)),
+            artifacts=tuple(artifacts),
+            stdout_ref=_reference_from_dict(value.get("stdout_ref")),
+            stderr_ref=_reference_from_dict(value.get("stderr_ref")),
+        )
+
 
 @dataclass(frozen=True)
 class HarnessApplyResult:
@@ -162,6 +188,34 @@ class HarnessApplyResult:
             "report_path": self.report_path,
             "cleanup_status": self.cleanup_status,
         }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> "HarnessApplyResult":
+        evidence = value.get("evidence", [])
+        consumption = value.get("consumption", {})
+        if not isinstance(evidence, list) or not all(
+            isinstance(item, dict) for item in evidence
+        ):
+            raise ValueError("Harness Apply evidence must be an object list")
+        if not isinstance(consumption, dict):
+            raise ValueError("Harness Apply consumption must be an object")
+        return cls(
+            status=str(value.get("status", "")),
+            changed=bool(value.get("changed", False)),
+            repository=str(value.get("repository", "")),
+            branch=str(value.get("branch", "")),
+            worktree=str(value.get("worktree", "")),
+            base_commit=str(value.get("base_commit", "")),
+            candidate_commit=str(value.get("candidate_commit", "")),
+            evidence=tuple(
+                HarnessProbeEvidence.from_dict(item)
+                for item in evidence
+                if isinstance(item, dict)
+            ),
+            consumption=dict(consumption),
+            report_path=str(value.get("report_path", "")),
+            cleanup_status=str(value.get("cleanup_status", "")),
+        )
 
 
 def preview_python_l0_apply(
@@ -646,6 +700,20 @@ def _reference_dict(
         "media_type": reference.media_type,
         "label": reference.label,
     }
+
+
+def _reference_from_dict(value: object) -> Optional[EvidenceReference]:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("Evidence reference must be an object")
+    return EvidenceReference(
+        artifact_id=str(value.get("artifact_id", "")),
+        sha256=str(value.get("sha256", "")),
+        size_bytes=int(value.get("size_bytes", 0)),
+        media_type=str(value.get("media_type", "")),
+        label=str(value.get("label", "")),
+    )
 
 
 def _ensure_candidate_worktree(

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Optional, Sequence, Tuple
@@ -9,6 +10,12 @@ from typing import Optional, Sequence, Tuple
 from .agent import AgentRouter, ClaudeCodeCliAdapter, CodexCliAdapter
 from .daemon import AgentDaemon, DaemonClient, DaemonError
 from .handoff_bridge import GoalHandoffBridge
+from .github_pipeline import (
+    GhApiGitHubSource,
+    GitHubActionsAdapter,
+    GitHubPipelineRequest,
+)
+from ._harness_apply import HarnessApplyResult
 from .harness_setup import (
     HarnessApplyRequest,
     HarnessSetup,
@@ -35,6 +42,7 @@ def main(arguments: Optional[Sequence[str]] = None) -> int:
         "setup": _run_setup,
         "skills": _run_skills,
         "doctor": _run_doctor,
+        "pipeline": _run_pipeline,
         "goal": _run_goal,
         "daemon": _run_daemon,
         "evidence": _run_evidence,
@@ -112,6 +120,32 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     doctor.add_argument("--codex-bin", default="codex")
     doctor.add_argument("--claude-bin", default="claude")
+
+    pipeline = commands.add_parser("pipeline")
+    pipeline_commands = pipeline.add_subparsers(
+        dest="pipeline_command",
+        required=True,
+    )
+    pipeline_verify = pipeline_commands.add_parser("verify")
+    pipeline_verify.add_argument("--candidate-report", required=True, type=Path)
+    pipeline_verify.add_argument("--owner", required=True)
+    pipeline_verify.add_argument("--repository", required=True)
+    pipeline_verify.add_argument(
+        "--required-check",
+        action="append",
+        default=[],
+    )
+    pipeline_verify.add_argument(
+        "--required-artifact",
+        action="append",
+        default=[],
+    )
+    pipeline_verify.add_argument(
+        "--missing-variable",
+        action="append",
+        default=[],
+    )
+    pipeline_verify.add_argument("--state-dir", required=True, type=Path)
 
     goal = commands.add_parser("goal")
     goal_commands = goal.add_subparsers(dest="goal_command", required=True)
@@ -431,6 +465,37 @@ def _run_doctor(options: argparse.Namespace) -> int:
     return 0 if report.status == "ok" else 1
 
 
+def _run_pipeline(options: argparse.Namespace) -> int:
+    if options.pipeline_command != "verify":
+        raise ValueError(f"unsupported pipeline command: {options.pipeline_command}")
+    try:
+        value = json.loads(options.candidate_report.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read candidate report: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError("candidate report must be a JSON object")
+    request = GitHubPipelineRequest(
+        owner=options.owner,
+        repository=options.repository,
+        candidate=HarnessApplyResult.from_dict(value),
+        required_checks=tuple(options.required_check),
+        required_artifacts=tuple(options.required_artifact),
+        missing_variables=tuple(
+            _named_values(options.missing_variable, "missing variable")
+        ),
+    )
+    executable = os.environ.get("AIWB_GH_BIN", "/usr/bin/gh")
+    result = HarnessSetup().verify_pipeline(
+        request,
+        adapter=GitHubActionsAdapter(
+            GhApiGitHubSource(executable=executable)
+        ),
+        state_dir=options.state_dir,
+    )
+    _print_json(result.to_dict())
+    return 0 if result.status in {"pipeline_pending", "verified"} else 1
+
+
 def _run_goal(options: argparse.Namespace) -> int:
     if options.goal_command == "bridge":
         result = GoalHandoffBridge().create(
@@ -600,6 +665,19 @@ def _pack_profiles(
             raise ValueError("pack profiles require a matching --install-pack")
         selected[pack].append(profile)
     return {pack: tuple(profiles) for pack, profiles in selected.items() if profiles}
+
+
+def _named_values(
+    values: Sequence[str],
+    label: str,
+) -> Tuple[Tuple[str, str], ...]:
+    result = []
+    for value in values:
+        name, separator, purpose = value.partition("=")
+        if not separator or not name.strip() or not purpose.strip():
+            raise ValueError(f"{label} must use NAME=PURPOSE")
+        result.append((name.strip(), purpose.strip()))
+    return tuple(result)
 
 
 def _pack_to_dict(pack) -> dict[str, object]:

--- a/tools/agent-orchestrator/src/aiwb/github_pipeline.py
+++ b/tools/agent-orchestrator/src/aiwb/github_pipeline.py
@@ -1,0 +1,614 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Protocol, Sequence, Tuple
+
+from ._harness_apply import HarnessApplyResult
+from .intake import IntakeBlocker
+
+
+@dataclass(frozen=True)
+class GitHubPipelineRequest:
+    owner: str
+    repository: str
+    candidate: HarnessApplyResult
+    required_checks: Tuple[str, ...]
+    required_artifacts: Tuple[str, ...] = ()
+    missing_variables: Tuple[Tuple[str, str], ...] = ()
+
+    @property
+    def commit(self) -> str:
+        return self.candidate.candidate_commit
+
+
+@dataclass(frozen=True)
+class PipelineEvidence:
+    kind: str
+    name: str
+    identifier: str
+    commit: str
+    status: str
+    conclusion: str
+    attempt: int
+    url: str
+    stale: bool = False
+    expired: bool = False
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "kind": self.kind,
+            "name": self.name,
+            "identifier": self.identifier,
+            "commit": self.commit,
+            "status": self.status,
+            "conclusion": self.conclusion,
+            "attempt": self.attempt,
+            "url": self.url,
+            "stale": self.stale,
+            "expired": self.expired,
+        }
+
+
+@dataclass(frozen=True)
+class PipelineVerification:
+    status: str
+    provider: str
+    repository: str
+    candidate_commit: str
+    evidence: Tuple[PipelineEvidence, ...]
+    blockers: Tuple[IntakeBlocker, ...]
+    retry_count: int
+    flaky: bool
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "status": self.status,
+            "provider": self.provider,
+            "repository": self.repository,
+            "candidate_commit": self.candidate_commit,
+            "evidence": [item.to_dict() for item in self.evidence],
+            "blockers": [
+                {
+                    "code": item.code,
+                    "message": item.message,
+                    "action": item.action,
+                }
+                for item in self.blockers
+            ],
+            "retry_count": self.retry_count,
+            "flaky": self.flaky,
+        }
+
+
+class GitHubReadSource(Protocol):
+    def workflow_runs(
+        self,
+        request: GitHubPipelineRequest,
+    ) -> Sequence[Mapping[str, object]]:
+        ...
+
+    def run_jobs(
+        self,
+        request: GitHubPipelineRequest,
+        run_id: int,
+    ) -> Sequence[Mapping[str, object]]:
+        ...
+
+    def check_runs(
+        self,
+        request: GitHubPipelineRequest,
+    ) -> Sequence[Mapping[str, object]]:
+        ...
+
+    def artifacts_for_run(
+        self,
+        request: GitHubPipelineRequest,
+        run_id: int,
+    ) -> Sequence[Mapping[str, object]]:
+        ...
+
+
+class GitHubActionsAdapter:
+    """Map side-effect-free GitHub Actions reads into Harness verification."""
+
+    def __init__(self, source: GitHubReadSource) -> None:
+        self._source = source
+
+    def verify(self, request: GitHubPipelineRequest) -> PipelineVerification:
+        _validate_request(request)
+        raw_runs = tuple(self._source.workflow_runs(request))
+        raw_checks = tuple(self._source.check_runs(request))
+        exact_runs = tuple(
+            run for run in raw_runs if str(run.get("head_sha", "")) == request.commit
+        )
+        evidence = [
+            _run_evidence(run, request.commit)
+            for run in raw_runs
+        ]
+        evidence.extend(
+            _check_evidence(check, request.commit)
+            for check in raw_checks
+        )
+        blockers = []
+        for name, purpose in request.missing_variables:
+            blockers.append(
+                IntakeBlocker(
+                    code="required_variable_missing",
+                    message=(
+                        f"Required pipeline variable is missing: {name} "
+                        f"(purpose: {purpose})."
+                    ),
+                    action=(
+                        "Ask the repository owner to configure the named variable; "
+                        "do not provide or persist its value in AI Workbench."
+                    ),
+                )
+            )
+        if not exact_runs:
+            blockers.append(
+                IntakeBlocker(
+                    code="exact_commit_missing",
+                    message=(
+                        "No GitHub Actions run exists for the exact candidate commit."
+                    ),
+                    action=(
+                        "Publish the exact candidate commit through the approved "
+                        "repository flow and wait for its configured workflow."
+                    ),
+                )
+            )
+            return _result(request, evidence, blockers)
+
+        exact_runs = tuple(sorted(exact_runs, key=_attempt_key))
+        for run in exact_runs:
+            run_id = _integer(run.get("id"), "workflow run id")
+            jobs = tuple(self._source.run_jobs(request, run_id))
+            evidence.extend(
+                _job_evidence(job, request.commit, run)
+                for job in jobs
+            )
+            artifacts = tuple(self._source.artifacts_for_run(request, run_id))
+            evidence.extend(
+                _artifact_evidence(artifact, request.commit, run)
+                for artifact in artifacts
+            )
+
+        exact_checks = tuple(
+            check
+            for check in raw_checks
+            if str(check.get("head_sha", "")) == request.commit
+        )
+        latest_run = exact_runs[-1]
+        latest_run_id = _integer(latest_run.get("id"), "workflow run id")
+        run_status = str(latest_run.get("status", ""))
+        run_conclusion = str(latest_run.get("conclusion") or "")
+        pending = run_status != "completed"
+        check_by_name = {
+            str(check.get("name", "")): check
+            for check in exact_checks
+        }
+        for required in request.required_checks:
+            check = check_by_name.get(required)
+            if check is None:
+                if not pending:
+                    blockers.append(
+                        IntakeBlocker(
+                            code="required_check_missing",
+                            message=f"Required check is missing: {required}.",
+                            action=(
+                                "Confirm the workflow check name and wait for the exact "
+                                "candidate commit check to appear."
+                            ),
+                        )
+                    )
+                continue
+            status = str(check.get("status", ""))
+            conclusion = str(check.get("conclusion") or "")
+            if status != "completed":
+                pending = True
+            elif conclusion != "success":
+                blockers.append(
+                    IntakeBlocker(
+                        code="required_check_failed",
+                        message=(
+                            f"Required check {required!r} concluded {conclusion or 'unknown'}."
+                        ),
+                        action=(
+                            "Inspect the first failing run and job Evidence; fix the "
+                            "candidate without weakening or quarantining the gate."
+                        ),
+                    )
+                )
+
+        if run_status == "completed" and run_conclusion != "success":
+            blockers.append(
+                IntakeBlocker(
+                    code="required_check_failed",
+                    message=(
+                        f"Latest exact-commit workflow concluded "
+                        f"{run_conclusion or 'unknown'}."
+                    ),
+                    action="Inspect the retained run and job Evidence before retrying.",
+                )
+            )
+        latest_artifacts = tuple(
+            item
+            for item in evidence
+            if item.kind == "artifact"
+            and item.identifier.startswith(f"{latest_run_id}:")
+            and not item.expired
+        )
+        artifact_names = {item.name for item in latest_artifacts}
+        if not pending and not blockers:
+            for required in request.required_artifacts:
+                if required not in artifact_names:
+                    blockers.append(
+                        IntakeBlocker(
+                            code="required_artifact_missing",
+                            message=f"Required pipeline artifact is missing: {required}.",
+                            action=(
+                                "Upload the required artifact from the exact successful "
+                                "candidate run and retain its GitHub reference."
+                            ),
+                        )
+                    )
+        return _result(request, evidence, blockers, pending=pending)
+
+
+class GhApiGitHubSource:
+    """Read GitHub Actions facts through authenticated `gh api -X GET` calls."""
+
+    def __init__(
+        self,
+        executable: str = "/usr/bin/gh",
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        self._executable = executable
+        self._environment = (
+            dict(environment)
+            if environment is not None
+            else dict(os.environ)
+        )
+
+    def workflow_runs(
+        self,
+        request: GitHubPipelineRequest,
+    ) -> Sequence[Mapping[str, object]]:
+        value = self._get(
+            f"repos/{request.owner}/{request.repository}/actions/runs",
+            {
+                "branch": request.candidate.branch,
+                "per_page": "100",
+            },
+        )
+        return _mapping_list(value, "workflow_runs")
+
+    def run_jobs(
+        self,
+        request: GitHubPipelineRequest,
+        run_id: int,
+    ) -> Sequence[Mapping[str, object]]:
+        value = self._get(
+            f"repos/{request.owner}/{request.repository}/actions/runs/{run_id}/jobs",
+            {"filter": "all", "per_page": "100"},
+        )
+        jobs = []
+        for job in _mapping_list(value, "jobs"):
+            jobs.append({**job, "run_id": run_id})
+        return tuple(jobs)
+
+    def check_runs(
+        self,
+        request: GitHubPipelineRequest,
+    ) -> Sequence[Mapping[str, object]]:
+        value = self._get(
+            f"repos/{request.owner}/{request.repository}/commits/{request.commit}/check-runs",
+            {"filter": "all", "per_page": "100"},
+            accept="application/vnd.github+json",
+        )
+        return _mapping_list(value, "check_runs")
+
+    def artifacts_for_run(
+        self,
+        request: GitHubPipelineRequest,
+        run_id: int,
+    ) -> Sequence[Mapping[str, object]]:
+        value = self._get(
+            f"repos/{request.owner}/{request.repository}/actions/runs/{run_id}/artifacts",
+            {"per_page": "100"},
+        )
+        artifacts = []
+        for artifact in _mapping_list(value, "artifacts"):
+            workflow_run = artifact.get("workflow_run")
+            workflow_run = workflow_run if isinstance(workflow_run, dict) else {}
+            artifacts.append(
+                {
+                    **artifact,
+                    "workflow_run": {
+                        **workflow_run,
+                        "id": run_id,
+                        "head_sha": request.commit,
+                    },
+                }
+            )
+        return tuple(artifacts)
+
+    def _get(
+        self,
+        endpoint: str,
+        fields: Mapping[str, str],
+        *,
+        accept: str = "",
+    ) -> Mapping[str, object]:
+        command = [self._executable, "api", "-X", "GET", endpoint]
+        for name, value in fields.items():
+            command.extend(["-f", f"{name}={value}"])
+        if accept:
+            command.extend(["-H", f"Accept: {accept}"])
+        completed = subprocess.run(
+            command,
+            env=self._environment,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+        )
+        if completed.returncode != 0:
+            raise ValueError(
+                f"GitHub read failed for {endpoint}: "
+                + (completed.stderr.strip() or completed.stdout.strip())
+            )
+        try:
+            value = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"GitHub returned invalid JSON for {endpoint}") from error
+        if not isinstance(value, dict):
+            raise ValueError(f"GitHub response must be an object: {endpoint}")
+        return value
+
+
+def append_pipeline_observation(
+    request: GitHubPipelineRequest,
+    result: PipelineVerification,
+    *,
+    state_dir,
+) -> str:
+    state_dir = Path(state_dir).expanduser().resolve()
+    repository = Path(request.candidate.repository).expanduser().resolve()
+    try:
+        state_dir.relative_to(repository)
+    except ValueError:
+        pass
+    else:
+        raise ValueError(
+            "Pipeline verification state directory must stay outside the target repository"
+        )
+    path = (
+        state_dir
+        / "reports"
+        / "pipeline"
+        / request.commit
+        / "report.json"
+    )
+    observations = []
+    if path.is_file():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError(f"cannot read pipeline report: {error}") from error
+        if not isinstance(existing, dict):
+            raise ValueError("pipeline report must be a JSON object")
+        value = existing.get("observations", [])
+        if not isinstance(value, list):
+            raise ValueError("pipeline report observations must be a list")
+        observations.extend(item for item in value if isinstance(item, dict))
+    observations.append(result.to_dict())
+    payload = {
+        "provider": result.provider,
+        "repository": result.repository,
+        "candidate_commit": result.candidate_commit,
+        "status": result.status,
+        "observations": observations,
+    }
+    _write_json_atomically(path, payload)
+    return str(path)
+
+
+def _result(
+    request: GitHubPipelineRequest,
+    evidence: Sequence[PipelineEvidence],
+    blockers: Sequence[IntakeBlocker],
+    *,
+    pending: bool = False,
+) -> PipelineVerification:
+    attempts = sorted(
+        {
+            item.attempt
+            for item in evidence
+            if item.kind == "run" and not item.stale
+        }
+    )
+    conclusions = {
+        item.conclusion
+        for item in evidence
+        if item.kind == "run" and not item.stale and item.conclusion
+    }
+    flaky = "failure" in conclusions and "success" in conclusions
+    if blockers:
+        status = "verification_failed"
+    elif pending:
+        status = "pipeline_pending"
+    else:
+        status = "verified"
+    return PipelineVerification(
+        status=status,
+        provider="github-actions",
+        repository=f"{request.owner}/{request.repository}",
+        candidate_commit=request.commit,
+        evidence=tuple(evidence),
+        blockers=tuple(_dedupe_blockers(blockers)),
+        retry_count=max(0, len(attempts) - 1),
+        flaky=flaky,
+    )
+
+
+def _run_evidence(
+    run: Mapping[str, object],
+    commit: str,
+) -> PipelineEvidence:
+    observed = str(run.get("head_sha", ""))
+    return PipelineEvidence(
+        kind="run",
+        name=str(run.get("name", "")),
+        identifier=str(run.get("id", "")),
+        commit=observed,
+        status=str(run.get("status", "")),
+        conclusion=str(run.get("conclusion") or ""),
+        attempt=_integer(run.get("run_attempt", 1), "run attempt"),
+        url=str(run.get("html_url", "")),
+        stale=observed != commit,
+    )
+
+
+def _job_evidence(
+    job: Mapping[str, object],
+    commit: str,
+    run: Mapping[str, object],
+) -> PipelineEvidence:
+    observed = str(run.get("head_sha", ""))
+    run_id = _integer(run.get("id"), "workflow run id")
+    return PipelineEvidence(
+        kind="job",
+        name=str(job.get("name", "")),
+        identifier=f"{run_id}:{job.get('id', '')}",
+        commit=observed,
+        status=str(job.get("status", "")),
+        conclusion=str(job.get("conclusion") or ""),
+        attempt=_integer(job.get("run_attempt", run.get("run_attempt", 1)), "job attempt"),
+        url=str(job.get("html_url", "")),
+        stale=observed != commit,
+    )
+
+
+def _check_evidence(
+    check: Mapping[str, object],
+    commit: str,
+) -> PipelineEvidence:
+    observed = str(check.get("head_sha", ""))
+    return PipelineEvidence(
+        kind="check",
+        name=str(check.get("name", "")),
+        identifier=str(check.get("id", "")),
+        commit=observed,
+        status=str(check.get("status", "")),
+        conclusion=str(check.get("conclusion") or ""),
+        attempt=1,
+        url=str(check.get("html_url", "")),
+        stale=observed != commit,
+    )
+
+
+def _artifact_evidence(
+    artifact: Mapping[str, object],
+    commit: str,
+    run: Mapping[str, object],
+) -> PipelineEvidence:
+    workflow_run = artifact.get("workflow_run")
+    workflow_run = workflow_run if isinstance(workflow_run, dict) else {}
+    observed = str(workflow_run.get("head_sha") or run.get("head_sha", ""))
+    run_id = _integer(run.get("id"), "workflow run id")
+    return PipelineEvidence(
+        kind="artifact",
+        name=str(artifact.get("name", "")),
+        identifier=f"{run_id}:{artifact.get('id', '')}",
+        commit=observed,
+        status="completed",
+        conclusion="success" if artifact.get("expired") is not True else "expired",
+        attempt=_integer(run.get("run_attempt", 1), "artifact attempt"),
+        url=str(artifact.get("archive_download_url", "")),
+        stale=observed != commit,
+        expired=artifact.get("expired") is True,
+    )
+
+
+def _validate_request(request: GitHubPipelineRequest) -> None:
+    if request.candidate.status != "configured_local":
+        raise ValueError("Pipeline verification requires configured_local candidate")
+    if not request.owner or not request.repository:
+        raise ValueError("GitHub owner and repository are required")
+    if len(request.commit) != 40:
+        raise ValueError("candidate commit must be a full Git commit SHA")
+    if not request.required_checks:
+        raise ValueError("at least one required pipeline check is required")
+    for name, purpose in request.missing_variables:
+        if not name or not purpose:
+            raise ValueError(
+                "missing pipeline variables require a non-empty name and purpose"
+            )
+
+
+def _attempt_key(run: Mapping[str, object]) -> Tuple[int, int]:
+    return (
+        _integer(run.get("run_attempt", 1), "run attempt"),
+        _integer(run.get("id"), "workflow run id"),
+    )
+
+
+def _integer(value: object, label: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{label} must be an integer")
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{label} must be an integer") from error
+    if result <= 0:
+        raise ValueError(f"{label} must be positive")
+    return result
+
+
+def _mapping_list(
+    value: Mapping[str, object],
+    key: str,
+) -> Tuple[Mapping[str, object], ...]:
+    items = value.get(key, [])
+    if not isinstance(items, list):
+        raise ValueError(f"GitHub response {key} must be a list")
+    if not all(isinstance(item, dict) for item in items):
+        raise ValueError(f"GitHub response {key} items must be objects")
+    return tuple(item for item in items if isinstance(item, dict))
+
+
+def _dedupe_blockers(
+    blockers: Sequence[IntakeBlocker],
+) -> Tuple[IntakeBlocker, ...]:
+    return tuple(
+        {
+            (item.code, item.message, item.action): item
+            for item in blockers
+        }.values()
+    )
+
+
+def _write_json_atomically(path, value: Mapping[str, object]) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(value, output, indent=2, sort_keys=True)
+            output.write("\n")
+        temporary.replace(path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise

--- a/tools/agent-orchestrator/src/aiwb/harness_setup.py
+++ b/tools/agent-orchestrator/src/aiwb/harness_setup.py
@@ -27,6 +27,12 @@ from ._harness_apply import (
     load_python_l0_apply_approval,
     preview_python_l0_apply,
 )
+from .github_pipeline import (
+    GitHubActionsAdapter,
+    GitHubPipelineRequest,
+    PipelineVerification,
+    append_pipeline_observation,
+)
 from .project import DoctorReport, ProjectDoctor, ProjectInitializer
 from .skills import (
     SkillCatalog,
@@ -396,6 +402,21 @@ class HarnessSetup:
             approval,
             state_dir=state_dir,
         )
+
+    def verify_pipeline(
+        self,
+        request: GitHubPipelineRequest,
+        *,
+        adapter: GitHubActionsAdapter,
+        state_dir: Path,
+    ) -> PipelineVerification:
+        result = adapter.verify(request)
+        append_pipeline_observation(
+            request,
+            result,
+            state_dir=state_dir,
+        )
+        return result
 
     def apply(self, request: HarnessApplyRequest) -> HarnessCandidate:
         if request.plan.state != "planned":

--- a/tools/agent-orchestrator/tests/test_github_pipeline.py
+++ b/tools/agent-orchestrator/tests/test_github_pipeline.py
@@ -1,0 +1,622 @@
+from __future__ import annotations
+
+import sys
+import json
+import tempfile
+import os
+from pathlib import Path
+
+import pytest
+
+TOOL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOL_ROOT / "src"))
+
+from aiwb import (  # noqa: E402
+    GitHubActionsAdapter,
+    GhApiGitHubSource,
+    GitHubPipelineRequest,
+    HarnessSetup,
+    HarnessApplyResult,
+)
+from aiwb.cli import main as cli_main  # noqa: E402
+
+
+COMMIT = "a" * 40
+
+
+class FixtureSource:
+    def __init__(self, *, runs=(), jobs=(), checks=(), artifacts=()) -> None:
+        self.runs = tuple(runs)
+        self.jobs = tuple(jobs)
+        self.checks = tuple(checks)
+        self.artifacts = tuple(artifacts)
+        self.calls = []
+
+    def workflow_runs(self, request):
+        self.calls.append(("runs", request.commit))
+        return self.runs
+
+    def run_jobs(self, request, run_id):
+        self.calls.append(("jobs", run_id))
+        return tuple(item for item in self.jobs if item["run_id"] == run_id)
+
+    def check_runs(self, request):
+        self.calls.append(("checks", request.commit))
+        return self.checks
+
+    def artifacts_for_run(self, request, run_id):
+        self.calls.append(("artifacts", run_id))
+        return tuple(
+            item for item in self.artifacts if item["workflow_run"]["id"] == run_id
+        )
+
+
+def test_pending_exact_commit_transitions_configured_local_to_pipeline_pending() -> None:
+    source = FixtureSource(
+        runs=(
+            _run(10, commit=COMMIT, status="in_progress", conclusion=None),
+        ),
+        jobs=(
+            _job(10, 100, status="in_progress", conclusion=None),
+        ),
+        checks=(
+            _check("harness", commit=COMMIT, status="in_progress", conclusion=None),
+        ),
+    )
+
+    result = GitHubActionsAdapter(source).verify(_request())
+
+    assert result.status == "pipeline_pending"
+    assert result.candidate_commit == COMMIT
+    assert result.provider == "github-actions"
+    assert {item.kind for item in result.evidence} >= {"run", "job", "check"}
+    assert all(item.commit == COMMIT for item in result.evidence)
+
+
+def test_only_successful_required_exact_commit_checks_can_verify() -> None:
+    source = FixtureSource(
+        runs=(
+            _run(10, commit=COMMIT, status="completed", conclusion="success"),
+        ),
+        jobs=(
+            _job(10, 100, status="completed", conclusion="success"),
+        ),
+        checks=(
+            _check("harness", commit=COMMIT, status="completed", conclusion="success"),
+        ),
+        artifacts=(
+            _artifact(10, "harness-evidence", expired=False),
+        ),
+    )
+
+    result = GitHubActionsAdapter(source).verify(_request())
+
+    assert result.status == "verified"
+    assert result.blockers == ()
+    assert any(
+        item.kind == "artifact" and item.name == "harness-evidence"
+        for item in result.evidence
+    )
+    assert source.calls == [
+        ("runs", COMMIT),
+        ("checks", COMMIT),
+        ("jobs", 10),
+        ("artifacts", 10),
+    ]
+
+
+@pytest.mark.parametrize("conclusion", ["failure", "cancelled", "timed_out"])
+def test_terminal_failures_remain_explicitly_non_verified(conclusion: str) -> None:
+    source = FixtureSource(
+        runs=(
+            _run(10, commit=COMMIT, status="completed", conclusion=conclusion),
+        ),
+        jobs=(
+            _job(10, 100, status="completed", conclusion=conclusion),
+        ),
+        checks=(
+            _check("harness", commit=COMMIT, status="completed", conclusion=conclusion),
+        ),
+    )
+
+    result = GitHubActionsAdapter(source).verify(_request())
+
+    assert result.status == "verification_failed"
+    assert {blocker.code for blocker in result.blockers} >= {"required_check_failed"}
+    assert any(item.conclusion == conclusion for item in result.evidence)
+
+
+def test_stale_green_commit_never_verifies_candidate() -> None:
+    stale = "b" * 40
+    source = FixtureSource(
+        runs=(
+            _run(9, commit=stale, status="completed", conclusion="success"),
+        ),
+        checks=(
+            _check("harness", commit=stale, status="completed", conclusion="success"),
+        ),
+    )
+
+    result = GitHubActionsAdapter(source).verify(_request())
+
+    assert result.status == "verification_failed"
+    assert [blocker.code for blocker in result.blockers] == ["exact_commit_missing"]
+    assert any(item.commit == stale and item.stale for item in result.evidence)
+
+
+def test_missing_required_artifact_is_non_verified() -> None:
+    source = FixtureSource(
+        runs=(
+            _run(10, commit=COMMIT, status="completed", conclusion="success"),
+        ),
+        jobs=(
+            _job(10, 100, status="completed", conclusion="success"),
+        ),
+        checks=(
+            _check("harness", commit=COMMIT, status="completed", conclusion="success"),
+        ),
+    )
+
+    result = GitHubActionsAdapter(source).verify(_request())
+
+    assert result.status == "verification_failed"
+    assert [blocker.code for blocker in result.blockers] == [
+        "required_artifact_missing"
+    ]
+
+
+def test_expired_required_artifact_is_non_verified_and_visible() -> None:
+    source = FixtureSource(
+        runs=(
+            _run(10, commit=COMMIT, status="completed", conclusion="success"),
+        ),
+        jobs=(
+            _job(10, 100, status="completed", conclusion="success"),
+        ),
+        checks=(
+            _check("harness", commit=COMMIT, status="completed", conclusion="success"),
+        ),
+        artifacts=(
+            _artifact(10, "harness-evidence", expired=True),
+        ),
+    )
+
+    result = GitHubActionsAdapter(source).verify(_request())
+
+    assert result.status == "verification_failed"
+    assert [blocker.code for blocker in result.blockers] == [
+        "required_artifact_missing"
+    ]
+    assert any(
+        item.kind == "artifact"
+        and item.name == "harness-evidence"
+        and item.expired
+        for item in result.evidence
+    )
+
+
+def test_completed_run_with_missing_required_check_is_non_verified() -> None:
+    source = FixtureSource(
+        runs=(
+            _run(10, commit=COMMIT, status="completed", conclusion="success"),
+        ),
+        jobs=(
+            _job(10, 100, status="completed", conclusion="success"),
+        ),
+        checks=(),
+        artifacts=(
+            _artifact(10, "harness-evidence", expired=False),
+        ),
+    )
+
+    result = GitHubActionsAdapter(source).verify(_request())
+
+    assert result.status == "verification_failed"
+    assert [blocker.code for blocker in result.blockers] == [
+        "required_check_missing"
+    ]
+
+
+def test_in_progress_run_waits_for_required_check_to_appear() -> None:
+    source = FixtureSource(
+        runs=(
+            _run(10, commit=COMMIT, status="in_progress", conclusion=None),
+        ),
+        jobs=(
+            _job(10, 100, status="queued", conclusion=None),
+        ),
+        checks=(),
+    )
+
+    result = GitHubActionsAdapter(source).verify(_request())
+
+    assert result.status == "pipeline_pending"
+    assert result.blockers == ()
+
+
+def test_flaky_retry_preserves_first_failure_and_successful_retry() -> None:
+    source = FixtureSource(
+        runs=(
+            _run(10, commit=COMMIT, attempt=1, status="completed", conclusion="failure"),
+            _run(11, commit=COMMIT, attempt=2, status="completed", conclusion="success"),
+        ),
+        jobs=(
+            _job(10, 100, attempt=1, status="completed", conclusion="failure"),
+            _job(11, 101, attempt=2, status="completed", conclusion="success"),
+        ),
+        checks=(
+            _check(
+                "harness",
+                commit=COMMIT,
+                status="completed",
+                conclusion="success",
+            ),
+        ),
+        artifacts=(
+            _artifact(11, "harness-evidence", expired=False),
+        ),
+    )
+
+    result = GitHubActionsAdapter(source).verify(_request())
+
+    assert result.status == "verified"
+    runs = [item for item in result.evidence if item.kind == "run"]
+    assert [(item.attempt, item.conclusion) for item in runs] == [
+        (1, "failure"),
+        (2, "success"),
+    ]
+    assert result.retry_count == 1
+    assert result.flaky is True
+
+
+def test_adapter_rejects_non_configured_local_input() -> None:
+    configured = replace_apply_status("failed_local")
+    request = _request(configured=configured)
+
+    with pytest.raises(ValueError, match="configured_local"):
+        GitHubActionsAdapter(FixtureSource()).verify(request)
+
+
+def test_missing_variable_reports_only_name_and_purpose() -> None:
+    source = FixtureSource(
+        runs=(
+            _run(10, commit=COMMIT, status="completed", conclusion="success"),
+        ),
+        jobs=(
+            _job(10, 100, status="completed", conclusion="success"),
+        ),
+        checks=(
+            _check("harness", commit=COMMIT, status="completed", conclusion="success"),
+        ),
+        artifacts=(
+            _artifact(10, "harness-evidence", expired=False),
+        ),
+    )
+    request = GitHubPipelineRequest(
+        owner="blackfaced",
+        repository="ai-workbench",
+        candidate=replace_apply_status("configured_local"),
+        required_checks=("harness",),
+        required_artifacts=("harness-evidence",),
+        missing_variables=(("PACKAGE_TOKEN", "read private test dependency"),),
+    )
+
+    result = GitHubActionsAdapter(source).verify(request)
+
+    assert result.status == "verification_failed"
+    assert [blocker.code for blocker in result.blockers] == [
+        "required_variable_missing"
+    ]
+    payload = json.dumps(result.to_dict())
+    assert "PACKAGE_TOKEN" in payload
+    assert "read private test dependency" in payload
+    assert not _contains_key(result.to_dict(), {"value", "secret_value"})
+
+
+def test_harness_setup_persists_pipeline_observations_without_losing_failures() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        request = _request()
+        failed_source = FixtureSource(
+            runs=(
+                _run(10, commit=COMMIT, status="completed", conclusion="failure"),
+            ),
+            jobs=(
+                _job(10, 100, status="completed", conclusion="failure"),
+            ),
+            checks=(
+                _check(
+                    "harness",
+                    commit=COMMIT,
+                    status="completed",
+                    conclusion="failure",
+                ),
+            ),
+        )
+        success_source = FixtureSource(
+            runs=(
+                _run(
+                    10,
+                    commit=COMMIT,
+                    attempt=1,
+                    status="completed",
+                    conclusion="failure",
+                ),
+                _run(
+                    11,
+                    commit=COMMIT,
+                    attempt=2,
+                    status="completed",
+                    conclusion="success",
+                ),
+            ),
+            jobs=(
+                _job(10, 100, attempt=1, status="completed", conclusion="failure"),
+                _job(11, 101, attempt=2, status="completed", conclusion="success"),
+            ),
+            checks=(
+                _check(
+                    "harness",
+                    commit=COMMIT,
+                    status="completed",
+                    conclusion="success",
+                ),
+            ),
+            artifacts=(_artifact(11, "harness-evidence", expired=False),),
+        )
+
+        first = HarnessSetup().verify_pipeline(
+            request,
+            adapter=GitHubActionsAdapter(failed_source),
+            state_dir=root / "state",
+        )
+        second = HarnessSetup().verify_pipeline(
+            request,
+            adapter=GitHubActionsAdapter(success_source),
+            state_dir=root / "state",
+        )
+
+        assert first.status == "verification_failed"
+        assert second.status == "verified"
+        report = root / "state" / "reports" / "pipeline" / COMMIT / "report.json"
+        payload = json.loads(report.read_text(encoding="utf-8"))
+        assert [item["status"] for item in payload["observations"]] == [
+            "verification_failed",
+            "verified",
+        ]
+        assert any(
+            evidence["conclusion"] == "failure"
+            for observation in payload["observations"]
+            for evidence in observation["evidence"]
+        )
+
+
+def test_gh_source_uses_only_side_effect_free_get_requests() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        log = root / "commands.jsonl"
+        executable = root / "gh"
+        executable.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, sys\n"
+            "from pathlib import Path\n"
+            "args = sys.argv[1:]\n"
+            "with Path(os.environ['GH_FIXTURE_LOG']).open('a') as stream:\n"
+            "    stream.write(json.dumps(args) + '\\n')\n"
+            "endpoint = args[args.index('GET') + 1]\n"
+            "if endpoint.endswith('/actions/runs'):\n"
+            "    value = {'workflow_runs': []}\n"
+            "elif endpoint.endswith('/check-runs'):\n"
+            "    value = {'check_runs': []}\n"
+            "elif endpoint.endswith('/jobs'):\n"
+            "    value = {'jobs': []}\n"
+            "elif endpoint.endswith('/artifacts'):\n"
+            "    value = {'artifacts': []}\n"
+            "else:\n"
+            "    raise SystemExit(2)\n"
+            "print(json.dumps(value))\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        source = GhApiGitHubSource(
+            executable=str(executable),
+            environment={"GH_FIXTURE_LOG": str(log)},
+        )
+        request = _request()
+
+        assert source.workflow_runs(request) == ()
+        assert source.check_runs(request) == ()
+        assert source.run_jobs(request, 10) == ()
+        assert source.artifacts_for_run(request, 10) == ()
+
+        calls = [
+            json.loads(line)
+            for line in log.read_text(encoding="utf-8").splitlines()
+        ]
+        assert len(calls) == 4
+        assert all(call[:3] == ["api", "-X", "GET"] for call in calls)
+        runs_call = calls[0]
+        assert "branch=aiwb/harness-setup/candidate" in runs_call
+        assert all(not part.startswith("head_sha=") for part in runs_call)
+        serialized = json.dumps(calls)
+        assert "workflow_dispatch" not in serialized
+        assert "dispatches" not in serialized
+        assert "/actions/secrets" not in serialized
+        assert "/branches/" not in serialized
+
+
+def test_pipeline_cli_reads_candidate_report_and_returns_pending(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        candidate_report = root / "candidate.json"
+        candidate_report.write_text(
+            json.dumps(replace_apply_status("configured_local").to_dict()),
+            encoding="utf-8",
+        )
+        executable = root / "gh"
+        executable.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, sys\n"
+            "args = sys.argv[1:]\n"
+            "endpoint = args[args.index('GET') + 1]\n"
+            f"commit = {COMMIT!r}\n"
+            "if endpoint.endswith('/actions/runs'):\n"
+            "    value = {'workflow_runs': [{\n"
+            "        'id': 10, 'head_sha': commit, 'status': 'in_progress',\n"
+            "        'conclusion': None, 'run_attempt': 1,\n"
+            "        'html_url': 'https://github.test/runs/10',\n"
+            "        'name': 'AI Workbench Harness', 'event': 'push'}]}\n"
+            "elif endpoint.endswith('/check-runs'):\n"
+            "    value = {'check_runs': [{\n"
+            "        'id': 1000, 'name': 'harness', 'head_sha': commit,\n"
+            "        'status': 'in_progress', 'conclusion': None,\n"
+            "        'html_url': 'https://github.test/checks/1000'}]}\n"
+            "elif endpoint.endswith('/jobs'):\n"
+            "    value = {'jobs': [{\n"
+            "        'id': 100, 'name': 'harness', 'status': 'in_progress',\n"
+            "        'conclusion': None, 'run_attempt': 1,\n"
+            "        'html_url': 'https://github.test/jobs/100'}]}\n"
+            "elif endpoint.endswith('/artifacts'):\n"
+            "    value = {'artifacts': []}\n"
+            "else:\n"
+            "    raise SystemExit(2)\n"
+            "print(json.dumps(value))\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        monkeypatch.setenv("AIWB_GH_BIN", str(executable))
+
+        returncode = cli_main(
+            [
+                "pipeline",
+                "verify",
+                "--candidate-report",
+                str(candidate_report),
+                "--owner",
+                "blackfaced",
+                "--repository",
+                "ai-workbench",
+                "--required-check",
+                "harness",
+                "--required-artifact",
+                "harness-evidence",
+                "--state-dir",
+                str(root / "state"),
+            ]
+        )
+        value = json.loads(capsys.readouterr().out)
+
+        assert returncode == 0
+        assert value["status"] == "pipeline_pending"
+        report = root / "state" / "reports" / "pipeline" / COMMIT / "report.json"
+        assert report.is_file()
+
+
+def test_repository_github_workflow_has_stable_gate_and_pinned_actions() -> None:
+    workflow = (
+        TOOL_ROOT.parent.parent / ".github" / "workflows" / "aiwb-harness.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "name: AI Workbench Harness" in workflow
+    assert "  harness:\n    name: harness" in workflow
+    assert "name: harness-evidence" in workflow
+    assert "PYTHONPYCACHEPREFIX:" in workflow
+    assert "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" in workflow
+    assert "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065" in workflow
+    assert "actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08" in workflow
+    assert "workflow_dispatch" not in workflow
+    assert "actions/checkout@v4" not in workflow
+    assert "actions/setup-python@v5" not in workflow
+
+
+def _request(configured=None) -> GitHubPipelineRequest:
+    return GitHubPipelineRequest(
+        owner="blackfaced",
+        repository="ai-workbench",
+        candidate=configured or replace_apply_status("configured_local"),
+        required_checks=("harness",),
+        required_artifacts=("harness-evidence",),
+    )
+
+
+def replace_apply_status(status: str) -> HarnessApplyResult:
+    return HarnessApplyResult(
+        status=status,
+        changed=True,
+        repository="/tmp/project",
+        branch="aiwb/harness-setup/candidate",
+        worktree="/tmp/worktree",
+        base_commit="c" * 40,
+        candidate_commit=COMMIT,
+        evidence=(),
+        consumption={},
+        report_path="/tmp/report.json",
+        cleanup_status="not_required",
+    )
+
+
+def _run(
+    run_id: int,
+    *,
+    commit: str,
+    status: str,
+    conclusion,
+    attempt: int = 1,
+):
+    return {
+        "id": run_id,
+        "head_sha": commit,
+        "status": status,
+        "conclusion": conclusion,
+        "run_attempt": attempt,
+        "html_url": f"https://github.test/runs/{run_id}",
+        "name": "AI Workbench Harness",
+        "event": "push",
+    }
+
+
+def _job(run_id: int, job_id: int, *, status: str, conclusion, attempt: int = 1):
+    return {
+        "id": job_id,
+        "run_id": run_id,
+        "name": "harness",
+        "status": status,
+        "conclusion": conclusion,
+        "run_attempt": attempt,
+        "html_url": f"https://github.test/jobs/{job_id}",
+    }
+
+
+def _check(name: str, *, commit: str, status: str, conclusion):
+    return {
+        "id": 1000,
+        "name": name,
+        "head_sha": commit,
+        "status": status,
+        "conclusion": conclusion,
+        "html_url": "https://github.test/checks/1000",
+    }
+
+
+def _artifact(run_id: int, name: str, *, expired: bool):
+    return {
+        "id": 2000,
+        "name": name,
+        "expired": expired,
+        "archive_download_url": "https://api.github.test/artifacts/2000/zip",
+        "workflow_run": {"id": run_id, "head_sha": COMMIT},
+    }
+
+
+def _contains_key(value, forbidden: set[str]) -> bool:
+    if isinstance(value, dict):
+        return any(
+            str(key).lower() in forbidden or _contains_key(item, forbidden)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_key(item, forbidden) for item in value)
+    return False


### PR DESCRIPTION
## Summary
- add a side-effect-free GitHub Actions Adapter for branch runs, exact-commit checks, jobs, attempts, and artifact references
- enforce configured_local -> pipeline_pending -> verified/verification_failed semantics with stale-commit, missing/expired artifact, failure, cancellation, flaky retry, and missing-variable Evidence
- persist append-only pipeline observations and expose read-only `aiwb pipeline verify`
- add a pinned repository Harness workflow with stable `harness` check and `harness-evidence` artifact

## Test plan
- `PYTHONPYCACHEPREFIX=/tmp/aiwb-issue22-last-full PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m pytest -q` -> 183 passed
- focused Adapter/Apply/Setup/CLI/MCP suite -> 50 passed
- compileall, workflow YAML parse, Skill mirror, and diff checks passed

## Real exact-commit dogfood
- candidate commit: `a0bd7efe0929ad78a019ba3586a896bcc0fadba8`
- GitHub Actions run: https://github.com/blackfaced/ai-workbench/actions/runs/30362269785 -> success, attempt 1
- required check: `harness` -> success for the exact candidate commit
- required artifact: `harness-evidence` id `8689378530`, unexpired, exact workflow run
- `aiwb pipeline verify` result: `verified`, blockers `[]`, retry_count `0`, flaky `false`; Evidence kinds: run, check, job, artifact
- no workflow dispatch or repository-setting mutation was performed

Closes #22