### PR TITLE
feat: add versioned Harness Recipe Catalog

### DIFF
--- a/.codex/skills/refresh-harness-recipes/SKILL.md
+++ b/.codex/skills/refresh-harness-recipes/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: refresh-harness-recipes
+description: Audit or preview a source-backed public Harness Recipe Catalog refresh without applying upgrades.
+---
+
+# Refresh Harness Recipes
+
+Use this Skill only for public Recipe Catalog maintenance. It does not mutate
+approved projects or automatically upgrade tools.
+
+## Audit
+
+Run the deterministic bundled Catalog audit:
+
+```bash
+aiwb recipes audit
+```
+
+To audit one explicit Catalog artifact:
+
+```bash
+aiwb recipes audit --catalog /path/to/catalog.yaml
+```
+
+Report Recipe versions, official sources, review dates, stale findings,
+verification state, and the Catalog digest.
+
+## Refresh preview
+
+Prepare a proposed public Catalog from official sources without including
+private repository paths, code, configuration, policy, credentials, or private
+Catalog entries. Then run:
+
+```bash
+aiwb recipes refresh \
+  --proposed /path/to/proposed-public-catalog.yaml \
+  --output /path/to/refresh-preview.json
+```
+
+The result contains validation evidence, a reviewable version diff, and a
+separate tool upgrade plan. It does not mutate the bundled Catalog, any private
+Catalog, or approved project configuration. Review and commit accepted Catalog
+changes separately.

--- a/tools/agent-orchestrator/README.md
+++ b/tools/agent-orchestrator/README.md
@@ -104,6 +104,35 @@ This repository dogfoods the Adapter through
 `.github/workflows/aiwb-harness.yml`. The workflow uses pinned Actions commits,
 the stable `harness` check name, and uploads `harness-evidence`.
 
+## Recipe Catalog
+
+Harness planning resolves versioned Recipes in this order: project override,
+configured private Catalog, then bundled public Catalog. Every Recipe records
+official sources, review date, applicability, alternatives, cost, migration
+risk, report formats, verification state, and pinned tool versions. Only
+`verified` Recipes can authorize formal Harness gates; `plan_only` and
+`unsupported` remain advisory.
+
+Audit the bundled or an explicit Catalog:
+
+```bash
+aiwb recipes audit
+aiwb recipes audit --catalog /path/to/catalog.yaml
+```
+
+Preview a public refresh without mutating the bundled Catalog or any approved
+project:
+
+```bash
+aiwb recipes refresh \
+  --proposed /path/to/proposed-public-catalog.yaml \
+  --output /path/to/refresh-preview.json
+```
+
+The preview contains source-backed validation, deterministic version diffs, and
+a separate tool upgrade plan. Existing approved Harness Plans retain the Recipe
+versions already pinned in their approval artifacts.
+
 `GoalRunner.run(contract)` is the execution interface and test surface. It hides Contract validation, checkpoint persistence, Git worktree management, RED/GREEN machine gates, role prompts, Evidence capture, and recovery.
 
 `DaemonClient.submit/status/report/evidence` is the control interface. It hides the Unix socket protocol, background queue, SQLite job state, thread pool, stale socket handling, content-addressed Evidence retrieval, and process-restart recovery.

--- a/tools/agent-orchestrator/setup.cfg
+++ b/tools/agent-orchestrator/setup.cfg
@@ -21,6 +21,11 @@ test =
 [options.packages.find]
 where = src
 
+[options.package_data]
+aiwb =
+    recipes/*.yaml
+    skills/*/SKILL.md
+
 [options.entry_points]
 console_scripts =
     aiwb = aiwb.cli:main

--- a/tools/agent-orchestrator/skills/refresh-harness-recipes/SKILL.md
+++ b/tools/agent-orchestrator/skills/refresh-harness-recipes/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: refresh-harness-recipes
+description: Audit or preview a source-backed public Harness Recipe Catalog refresh without applying upgrades.
+---
+
+# Refresh Harness Recipes
+
+Use this Skill only for public Recipe Catalog maintenance. It does not mutate
+approved projects or automatically upgrade tools.
+
+## Audit
+
+Run the deterministic bundled Catalog audit:
+
+```bash
+aiwb recipes audit
+```
+
+To audit one explicit Catalog artifact:
+
+```bash
+aiwb recipes audit --catalog /path/to/catalog.yaml
+```
+
+Report Recipe versions, official sources, review dates, stale findings,
+verification state, and the Catalog digest.
+
+## Refresh preview
+
+Prepare a proposed public Catalog from official sources without including
+private repository paths, code, configuration, policy, credentials, or private
+Catalog entries. Then run:
+
+```bash
+aiwb recipes refresh \
+  --proposed /path/to/proposed-public-catalog.yaml \
+  --output /path/to/refresh-preview.json
+```
+
+The result contains validation evidence, a reviewable version diff, and a
+separate tool upgrade plan. It does not mutate the bundled Catalog, any private
+Catalog, or approved project configuration. Review and commit accepted Catalog
+changes separately.

--- a/tools/agent-orchestrator/src/aiwb/__init__.py
+++ b/tools/agent-orchestrator/src/aiwb/__init__.py
@@ -74,6 +74,14 @@ from .project import (
     ProjectInitResult,
     ProjectPolicy,
 )
+from .recipe_catalog import (
+    Recipe,
+    RecipeAudit,
+    RecipeCatalog,
+    RecipeFinding,
+    RecipeRefreshPreview,
+    RecipeResolution,
+)
 from .runner import (
     AttemptReport,
     CommandEvidence,
@@ -178,6 +186,12 @@ __all__ = [
     "ProviderQuotaError",
     "ProjectConfigError",
     "ProjectDoctor",
+    "Recipe",
+    "RecipeAudit",
+    "RecipeCatalog",
+    "RecipeFinding",
+    "RecipeRefreshPreview",
+    "RecipeResolution",
     "RunReport",
     "RunPaused",
     "RunStatus",

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -28,6 +28,7 @@ from .project import (
     ProjectConfigError,
     ProjectInitError,
 )
+from .recipe_catalog import RecipeCatalog
 from .runner import GoalRunner, preview_execution
 from .skills import SkillCatalog
 from .supervisor import LaunchdError, LaunchdService
@@ -43,6 +44,7 @@ def main(arguments: Optional[Sequence[str]] = None) -> int:
         "skills": _run_skills,
         "doctor": _run_doctor,
         "pipeline": _run_pipeline,
+        "recipes": _run_recipes,
         "goal": _run_goal,
         "daemon": _run_daemon,
         "evidence": _run_evidence,
@@ -146,6 +148,17 @@ def _build_parser() -> argparse.ArgumentParser:
         default=[],
     )
     pipeline_verify.add_argument("--state-dir", required=True, type=Path)
+
+    recipes = commands.add_parser("recipes")
+    recipe_commands = recipes.add_subparsers(
+        dest="recipes_command",
+        required=True,
+    )
+    recipe_audit = recipe_commands.add_parser("audit")
+    recipe_audit.add_argument("--catalog", type=Path)
+    recipe_refresh = recipe_commands.add_parser("refresh")
+    recipe_refresh.add_argument("--proposed", required=True, type=Path)
+    recipe_refresh.add_argument("--output", required=True, type=Path)
 
     goal = commands.add_parser("goal")
     goal_commands = goal.add_subparsers(dest="goal_command", required=True)
@@ -494,6 +507,22 @@ def _run_pipeline(options: argparse.Namespace) -> int:
     )
     _print_json(result.to_dict())
     return 0 if result.status in {"pipeline_pending", "verified"} else 1
+
+
+def _run_recipes(options: argparse.Namespace) -> int:
+    catalog = RecipeCatalog()
+    if options.recipes_command == "audit":
+        result = catalog.audit(catalog_path=options.catalog)
+        _print_json(result.to_dict())
+        return 0 if result.status == "ok" else 1
+    if options.recipes_command == "refresh":
+        result = catalog.refresh_preview(
+            proposed_catalog=options.proposed,
+            output_path=options.output,
+        )
+        _print_json(result.to_dict())
+        return 0 if result.status in {"review_required", "unchanged"} else 1
+    raise ValueError(f"unsupported Recipes command: {options.recipes_command}")
 
 
 def _run_goal(options: argparse.Namespace) -> int:

--- a/tools/agent-orchestrator/src/aiwb/harness_setup.py
+++ b/tools/agent-orchestrator/src/aiwb/harness_setup.py
@@ -34,6 +34,7 @@ from .github_pipeline import (
     append_pipeline_observation,
 )
 from .project import DoctorReport, ProjectDoctor, ProjectInitializer
+from .recipe_catalog import RecipeCatalog
 from .skills import (
     SkillCatalog,
     SkillCatalogSnapshot,
@@ -186,11 +187,15 @@ class HarnessSetup:
         analysis_provider: Optional[
             Callable[[Path], ExternalAnalysisEvidence]
         ] = None,
+        recipe_catalog: Optional[RecipeCatalog] = None,
+        project_recipe_catalog: Optional[Path] = None,
     ) -> None:
         self._catalog = catalog or SkillCatalog()
         self._pack_catalog = pack_catalog or SkillPackCatalog()
         self._command_runner = command_runner or _run_pack_command
         self._analysis_provider = analysis_provider
+        self._recipe_catalog = recipe_catalog or RecipeCatalog()
+        self._project_recipe_catalog = project_recipe_catalog
         self._initializer = ProjectInitializer()
 
     def inspect(self, request: HarnessSetupRequest) -> HarnessAssessment:
@@ -242,6 +247,14 @@ class HarnessSetup:
             if assessment.project_profile is not None
             else None
         )
+        recipe_versions = ()
+        if planning is not None:
+            resolution = self._recipe_catalog.resolve(
+                "python-l0-baseline",
+                project_catalog=self._project_recipe_catalog,
+            )
+            recipe = self._recipe_catalog.require_verified(resolution)
+            recipe_versions = ((recipe.name, recipe.version),)
         return HarnessPlan(
             state="planned",
             request=request,
@@ -250,9 +263,7 @@ class HarnessSetup:
                 planning.command_candidates if planning is not None else ()
             ),
             recipe_versions=(
-                (("python-l0-baseline", 1),)
-                if planning is not None
-                else ()
+                recipe_versions
             ),
             coverage_decision=(
                 "measure_baseline_before_threshold"

--- a/tools/agent-orchestrator/src/aiwb/recipe_catalog.py
+++ b/tools/agent-orchestrator/src/aiwb/recipe_catalog.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Mapping, Optional, Sequence, Tuple
+from urllib.parse import urlparse
+
+import yaml
+
+
+@dataclass(frozen=True)
+class Recipe:
+    name: str
+    version: int
+    official_sources: Tuple[str, ...]
+    reviewed_at: date
+    applicability: Tuple[str, ...]
+    alternatives: Tuple[str, ...]
+    cost: str
+    migration_risk: str
+    report_formats: Tuple[str, ...]
+    verification_state: str
+    tool_versions: Mapping[str, str]
+
+    @property
+    def effective_state(self) -> str:
+        return (
+            "verified"
+            if self.verification_state == "verified"
+            else "plan_only"
+        )
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "official_sources": list(self.official_sources),
+            "reviewed_at": self.reviewed_at.isoformat(),
+            "applicability": list(self.applicability),
+            "alternatives": list(self.alternatives),
+            "cost": self.cost,
+            "migration_risk": self.migration_risk,
+            "report_formats": list(self.report_formats),
+            "verification_state": self.verification_state,
+            "effective_state": self.effective_state,
+            "tool_versions": dict(self.tool_versions),
+        }
+
+
+@dataclass(frozen=True)
+class RecipeResolution:
+    recipe: Recipe
+    source: str
+    catalog_path: str
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "recipe": self.recipe.to_dict(),
+            "source": self.source,
+            "catalog_path": self.catalog_path,
+        }
+
+
+@dataclass(frozen=True)
+class RecipeFinding:
+    code: str
+    recipe: str
+    message: str
+    action: str
+
+    def to_dict(self) -> Mapping[str, str]:
+        return {
+            "code": self.code,
+            "recipe": self.recipe,
+            "message": self.message,
+            "action": self.action,
+        }
+
+
+@dataclass(frozen=True)
+class RecipeAudit:
+    status: str
+    catalog_path: str
+    catalog_digest: str
+    recipes: Tuple[Recipe, ...]
+    findings: Tuple[RecipeFinding, ...]
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "status": self.status,
+            "catalog_path": self.catalog_path,
+            "catalog_digest": self.catalog_digest,
+            "recipes": [recipe.to_dict() for recipe in self.recipes],
+            "findings": [finding.to_dict() for finding in self.findings],
+        }
+
+
+@dataclass(frozen=True)
+class RecipeRefreshPreview:
+    status: str
+    current_catalog_digest: str
+    proposed_catalog_digest: str
+    changes: Tuple[Mapping[str, object], ...]
+    upgrade_plan: Tuple[Mapping[str, object], ...]
+    validation: RecipeAudit
+    output_path: str
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "status": self.status,
+            "current_catalog_digest": self.current_catalog_digest,
+            "proposed_catalog_digest": self.proposed_catalog_digest,
+            "changes": [dict(item) for item in self.changes],
+            "upgrade_plan": [dict(item) for item in self.upgrade_plan],
+            "validation": self.validation.to_dict(),
+            "output_path": self.output_path,
+        }
+
+
+class RecipeCatalog:
+    """Resolve layered versioned Recipes and preview source-backed refreshes."""
+
+    def __init__(
+        self,
+        *,
+        private_catalogs: Sequence[Path] = (),
+        bundled_path: Optional[Path] = None,
+    ) -> None:
+        self._private_catalogs = tuple(
+            Path(path).expanduser().resolve() for path in private_catalogs
+        )
+        self._bundled_path = (
+            Path(bundled_path).expanduser().resolve()
+            if bundled_path is not None
+            else Path(__file__).resolve().parent / "recipes" / "public.yaml"
+        )
+
+    @property
+    def bundled_path(self) -> Path:
+        return self._bundled_path
+
+    def resolve(
+        self,
+        name: str,
+        *,
+        project_catalog: Optional[Path] = None,
+    ) -> RecipeResolution:
+        if not name:
+            raise ValueError("Recipe name is required")
+        if project_catalog is not None:
+            path = Path(project_catalog).expanduser().resolve()
+            match = _recipe_by_name(_load_catalog(path), name)
+            if match is not None:
+                _require_valid_version(match)
+                return RecipeResolution(match, "project", str(path))
+        private_matches = []
+        for path in self._private_catalogs:
+            match = _recipe_by_name(_load_catalog(path), name)
+            if match is not None:
+                private_matches.append((path, match))
+        if len(private_matches) > 1:
+            raise ValueError(f"private Catalog conflict for Recipe: {name}")
+        if private_matches:
+            path, match = private_matches[0]
+            _require_valid_version(match)
+            return RecipeResolution(match, "private", str(path))
+        match = _recipe_by_name(_load_catalog(self._bundled_path), name)
+        if match is None:
+            raise ValueError(f"unknown Recipe: {name}")
+        _require_valid_version(match)
+        return RecipeResolution(match, "bundled", str(self._bundled_path))
+
+    @staticmethod
+    def require_verified(resolution: RecipeResolution) -> Recipe:
+        if resolution.recipe.verification_state != "verified":
+            raise ValueError(
+                f"Recipe {resolution.recipe.name!r} cannot authorize formal gates: "
+                f"{resolution.recipe.verification_state}"
+            )
+        return resolution.recipe
+
+    def audit(
+        self,
+        *,
+        catalog_path: Optional[Path] = None,
+        today: Optional[date] = None,
+    ) -> RecipeAudit:
+        path = (
+            Path(catalog_path).expanduser().resolve()
+            if catalog_path is not None
+            else self._bundled_path
+        )
+        raw = path.read_bytes()
+        recipes = _load_catalog(path)
+        today = today or date.today()
+        findings = []
+        for recipe in recipes:
+            if recipe.version <= 0:
+                findings.append(
+                    RecipeFinding(
+                        code="recipe_version_invalid",
+                        recipe=recipe.name,
+                        message="Recipe version must be a positive integer.",
+                        action="Assign a positive version before review.",
+                    )
+                )
+            for source in recipe.official_sources:
+                parsed = urlparse(source)
+                if parsed.scheme != "https" or not parsed.netloc:
+                    findings.append(
+                        RecipeFinding(
+                            code="official_source_invalid",
+                            recipe=recipe.name,
+                            message=f"Official source is not an HTTPS URL: {source}",
+                            action="Replace it with a reviewed official HTTPS source.",
+                        )
+                    )
+            if (today - recipe.reviewed_at).days > 365:
+                findings.append(
+                    RecipeFinding(
+                        code="recipe_stale",
+                        recipe=recipe.name,
+                        message=(
+                            f"Recipe review is stale: {recipe.reviewed_at.isoformat()}."
+                        ),
+                        action="Review official sources and propose a new Recipe version.",
+                    )
+                )
+        return RecipeAudit(
+            status="ok" if not findings else "failed",
+            catalog_path=str(path),
+            catalog_digest=hashlib.sha256(raw).hexdigest(),
+            recipes=recipes,
+            findings=tuple(findings),
+        )
+
+    def refresh_preview(
+        self,
+        *,
+        proposed_catalog: Path,
+        output_path: Path,
+        today: Optional[date] = None,
+    ) -> RecipeRefreshPreview:
+        proposed_catalog = Path(proposed_catalog).expanduser().resolve()
+        output_path = Path(output_path).expanduser().resolve()
+        if output_path.exists():
+            raise ValueError(f"refresh preview output already exists: {output_path}")
+        current = self.audit(today=today)
+        proposed = self.audit(catalog_path=proposed_catalog, today=today)
+        current_by_name = {recipe.name: recipe for recipe in current.recipes}
+        proposed_by_name = {recipe.name: recipe for recipe in proposed.recipes}
+        changes = []
+        upgrades = []
+        refresh_findings = list(proposed.findings)
+        for name in sorted(set(current_by_name) | set(proposed_by_name)):
+            old = current_by_name.get(name)
+            new = proposed_by_name.get(name)
+            if old is None and new is not None:
+                changes.append(
+                    {
+                        "name": name,
+                        "change": "added",
+                        "from_version": None,
+                        "to_version": new.version,
+                    }
+                )
+                continue
+            if new is None and old is not None:
+                changes.append(
+                    {
+                        "name": name,
+                        "change": "removed",
+                        "from_version": old.version,
+                        "to_version": None,
+                    }
+                )
+                refresh_findings.append(
+                    RecipeFinding(
+                        code="recipe_removed",
+                        recipe=name,
+                        message="A bundled public Recipe was removed.",
+                        action=(
+                            "Keep the Recipe and mark it unsupported in a new "
+                            "version instead of removing its audit history."
+                        ),
+                    )
+                )
+                continue
+            assert old is not None and new is not None
+            if old.to_dict() == new.to_dict():
+                continue
+            change = (
+                "version_update"
+                if old.version != new.version
+                else "metadata_changed_without_version"
+            )
+            if new.version == old.version:
+                refresh_findings.append(
+                    RecipeFinding(
+                        code="recipe_version_not_incremented",
+                        recipe=name,
+                        message="Recipe metadata changed without a version increment.",
+                        action="Increment the Recipe version and review the upgrade plan.",
+                    )
+                )
+            elif new.version < old.version:
+                refresh_findings.append(
+                    RecipeFinding(
+                        code="recipe_version_regressed",
+                        recipe=name,
+                        message=(
+                            f"Recipe version regressed from {old.version} to {new.version}."
+                        ),
+                        action="Use a version greater than the current bundled Recipe.",
+                    )
+                )
+            changes.append(
+                {
+                    "name": name,
+                    "change": change,
+                    "from_version": old.version,
+                    "to_version": new.version,
+                }
+            )
+            if new.version > old.version:
+                tools = {
+                    tool: {"from": old.tool_versions.get(tool), "to": version}
+                    for tool, version in sorted(new.tool_versions.items())
+                    if old.tool_versions.get(tool) != version
+                }
+                upgrades.append(
+                    {
+                        "recipe": name,
+                        "from_version": old.version,
+                        "to_version": new.version,
+                        "tools": tools,
+                    }
+                )
+        proposed = RecipeAudit(
+            status="ok" if not refresh_findings else "failed",
+            catalog_path=proposed.catalog_path,
+            catalog_digest=proposed.catalog_digest,
+            recipes=proposed.recipes,
+            findings=tuple(refresh_findings),
+        )
+        result = RecipeRefreshPreview(
+            status=(
+                "review_required"
+                if proposed.status == "ok" and changes
+                else "invalid"
+                if proposed.status != "ok"
+                else "unchanged"
+            ),
+            current_catalog_digest=current.catalog_digest,
+            proposed_catalog_digest=proposed.catalog_digest,
+            changes=tuple(changes),
+            upgrade_plan=tuple(upgrades),
+            validation=proposed,
+            output_path=str(output_path),
+        )
+        _write_json_atomically(output_path, result.to_dict())
+        return result
+
+
+def _load_catalog(path: Path) -> Tuple[Recipe, ...]:
+    try:
+        value = yaml.safe_load(path.read_bytes())
+    except (OSError, yaml.YAMLError) as error:
+        raise ValueError(f"cannot read Recipe Catalog {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError("Recipe Catalog must be a mapping")
+    if value.get("schema_version") != 1:
+        raise ValueError("Recipe Catalog schema_version must be 1")
+    if value.get("kind") != "aiwb.recipe-catalog":
+        raise ValueError("Recipe Catalog kind must be aiwb.recipe-catalog")
+    items = value.get("recipes")
+    if not isinstance(items, list):
+        raise ValueError("Recipe Catalog recipes must be a list")
+    recipes = tuple(_parse_recipe(item) for item in items)
+    names = [recipe.name for recipe in recipes]
+    if len(names) != len(set(names)):
+        raise ValueError("Recipe Catalog contains duplicate Recipe names")
+    return recipes
+
+
+def _parse_recipe(value: object) -> Recipe:
+    if not isinstance(value, dict):
+        raise ValueError("Recipe must be a mapping")
+    name = _text(value, "name")
+    version = value.get("version")
+    if isinstance(version, bool) or not isinstance(version, int):
+        raise ValueError(f"Recipe {name!r} version must be an integer")
+    reviewed_at = _text(value, "reviewed_at")
+    try:
+        reviewed_date = date.fromisoformat(reviewed_at)
+    except ValueError as error:
+        raise ValueError(f"Recipe {name!r} reviewed_at must be an ISO date") from error
+    verification_state = _text(value, "verification_state")
+    if verification_state not in {"verified", "plan_only", "unsupported"}:
+        raise ValueError(
+            f"Recipe {name!r} verification_state is unsupported: {verification_state}"
+        )
+    tool_versions = value.get("tool_versions")
+    if not isinstance(tool_versions, dict) or not all(
+        isinstance(key, str)
+        and key
+        and isinstance(item, str)
+        and item
+        for key, item in tool_versions.items()
+    ):
+        raise ValueError(f"Recipe {name!r} tool_versions must be a string mapping")
+    return Recipe(
+        name=name,
+        version=version,
+        official_sources=_strings(value, "official_sources"),
+        reviewed_at=reviewed_date,
+        applicability=_strings(value, "applicability"),
+        alternatives=_strings(value, "alternatives"),
+        cost=_text(value, "cost"),
+        migration_risk=_text(value, "migration_risk"),
+        report_formats=_strings(value, "report_formats"),
+        verification_state=verification_state,
+        tool_versions={str(key): str(item) for key, item in tool_versions.items()},
+    )
+
+
+def _recipe_by_name(
+    recipes: Sequence[Recipe],
+    name: str,
+) -> Optional[Recipe]:
+    return next((recipe for recipe in recipes if recipe.name == name), None)
+
+
+def _require_valid_version(recipe: Recipe) -> None:
+    if recipe.version <= 0:
+        raise ValueError(
+            f"Recipe {recipe.name!r} version must be a positive integer"
+        )
+
+
+def _text(value: Mapping[str, object], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item:
+        raise ValueError(f"Recipe {key} must be a non-empty string")
+    return item
+
+
+def _strings(value: Mapping[str, object], key: str) -> Tuple[str, ...]:
+    items = value.get(key)
+    if not isinstance(items, list) or not items or not all(
+        isinstance(item, str) and item for item in items
+    ):
+        raise ValueError(f"Recipe {key} must be a non-empty string list")
+    return tuple(items)
+
+
+def _write_json_atomically(path: Path, value: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(value, output, indent=2, sort_keys=True)
+            output.write("\n")
+        temporary.replace(path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise

--- a/tools/agent-orchestrator/src/aiwb/recipes/public.yaml
+++ b/tools/agent-orchestrator/src/aiwb/recipes/public.yaml
@@ -1,0 +1,24 @@
+schema_version: 1
+kind: aiwb.recipe-catalog
+recipes:
+  - name: python-l0-baseline
+    version: 1
+    official_sources:
+      - https://docs.pytest.org/en/stable/
+      - https://docs.astral.sh/ruff/
+      - https://coverage.readthedocs.io/
+    reviewed_at: "2026-07-01"
+    applicability:
+      - language:python
+      - tier:l0
+    alternatives:
+      - preserve-project-tools
+    cost: low
+    migration_risk: low
+    report_formats:
+      - junit-xml
+      - coverage-xml
+    verification_state: verified
+    tool_versions:
+      pytest: "9.0"
+      ruff: "0.12.0"

--- a/tools/agent-orchestrator/src/aiwb/skills.py
+++ b/tools/agent-orchestrator/src/aiwb/skills.py
@@ -102,6 +102,14 @@ class SkillCatalog:
             source="bundled",
             path="skills/intake-aiwb-goal/SKILL.md",
         ),
+        SkillDescriptor(
+            name="refresh-harness-recipes",
+            description=(
+                "Audit and preview source-backed public Harness Recipe refreshes."
+            ),
+            source="bundled",
+            path="skills/refresh-harness-recipes/SKILL.md",
+        ),
     )
 
     def recommend(

--- a/tools/agent-orchestrator/tests/test_recipe_catalog.py
+++ b/tools/agent-orchestrator/tests/test_recipe_catalog.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+
+import pytest
+import yaml
+
+TOOL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOL_ROOT / "src"))
+
+from aiwb import HarnessSetup, HarnessSetupRequest, RecipeCatalog  # noqa: E402
+from aiwb.cli import main as cli_main  # noqa: E402
+
+
+def test_recipe_resolution_prefers_project_then_private_then_bundled() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        private = _write_catalog(
+            root / "private.yaml",
+            [_recipe(version=2, source="https://docs.pytest.org/en/stable/")],
+        )
+        project = _write_catalog(
+            root / "project.yaml",
+            [_recipe(version=3, source="https://docs.pytest.org/en/stable/")],
+        )
+
+        catalog = RecipeCatalog(private_catalogs=(private,))
+
+        project_result = catalog.resolve(
+            "python-l0-baseline",
+            project_catalog=project,
+        )
+        private_result = catalog.resolve("python-l0-baseline")
+        bundled_result = RecipeCatalog().resolve("python-l0-baseline")
+
+        assert (project_result.source, project_result.recipe.version) == (
+            "project",
+            3,
+        )
+        assert (private_result.source, private_result.recipe.version) == (
+            "private",
+            2,
+        )
+        assert (bundled_result.source, bundled_result.recipe.version) == (
+            "bundled",
+            1,
+        )
+
+
+def test_same_layer_recipe_conflict_is_explicit() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        first = _write_catalog(root / "first.yaml", [_recipe(version=2)])
+        second = _write_catalog(root / "second.yaml", [_recipe(version=3)])
+
+        with pytest.raises(ValueError, match="private Catalog conflict"):
+            RecipeCatalog(private_catalogs=(first, second)).resolve(
+                "python-l0-baseline"
+            )
+
+
+def test_plan_only_recipe_cannot_authorize_formal_gate() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        project = _write_catalog(
+            root / "project.yaml",
+            [
+                _recipe(
+                    version=4,
+                    verification_state="plan_only",
+                )
+            ],
+        )
+        catalog = RecipeCatalog()
+
+        result = catalog.resolve(
+            "python-l0-baseline",
+            project_catalog=project,
+        )
+
+        assert result.recipe.verification_state == "plan_only"
+        with pytest.raises(ValueError, match="cannot authorize formal gates"):
+            catalog.require_verified(result)
+
+        unsupported = _write_catalog(
+            root / "unsupported.yaml",
+            [
+                _recipe(
+                    version=5,
+                    verification_state="unsupported",
+                )
+            ],
+        )
+        unsupported_result = catalog.resolve(
+            "python-l0-baseline",
+            project_catalog=unsupported,
+        )
+        assert unsupported_result.recipe.verification_state == "unsupported"
+        assert unsupported_result.recipe.effective_state == "plan_only"
+        assert unsupported_result.recipe.to_dict()["effective_state"] == "plan_only"
+        with pytest.raises(ValueError, match="cannot authorize formal gates"):
+            catalog.require_verified(unsupported_result)
+
+
+def test_harness_plan_rejects_project_plan_only_recipe() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        project = _write_catalog(
+            root / "project.yaml",
+            [_recipe(version=2, verification_state="plan_only")],
+        )
+        setup = HarnessSetup(
+            recipe_catalog=RecipeCatalog(),
+            project_recipe_catalog=project,
+        )
+
+        with pytest.raises(ValueError, match="cannot authorize formal gates"):
+            setup.plan(
+                HarnessSetupRequest(
+                    repository=repository,
+                    planning_mode="python-l0",
+                )
+            )
+
+
+def test_recipe_audit_reports_stale_and_invalid_metadata() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        path = _write_catalog(
+            Path(directory) / "stale.yaml",
+            [
+                _recipe(
+                    version=2,
+                    reviewed_at="2024-01-01",
+                    source="not-a-url",
+                )
+            ],
+        )
+
+        report = RecipeCatalog().audit(
+            catalog_path=path,
+            today=date(2026, 7, 28),
+        )
+
+        assert report.status == "failed"
+        assert {item.code for item in report.findings} == {
+            "official_source_invalid",
+            "recipe_stale",
+        }
+        assert report.catalog_digest
+
+
+def test_refresh_preview_is_reviewable_and_never_mutates_bundled_or_project() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        project_policy = repository / ".ai-workbench" / "workflow.yaml"
+        project_policy.parent.mkdir()
+        project_policy.write_text("status: approved\n", encoding="utf-8")
+        proposed = _write_catalog(
+            root / "proposed-public.yaml",
+            [
+                _recipe(
+                    version=2,
+                    reviewed_at="2026-07-28",
+                    tool_versions={"pytest": "9.1.1", "ruff": "0.12.4"},
+                )
+            ],
+        )
+        output = root / "refresh-preview.json"
+        before_policy = project_policy.read_bytes()
+        bundled = RecipeCatalog().bundled_path
+        before_bundled = bundled.read_bytes()
+
+        result = RecipeCatalog().refresh_preview(
+            proposed_catalog=proposed,
+            output_path=output,
+            today=date(2026, 7, 28),
+        )
+
+        assert result.status == "review_required"
+        assert result.changes == (
+            {
+                "name": "python-l0-baseline",
+                "change": "version_update",
+                "from_version": 1,
+                "to_version": 2,
+            },
+        )
+        assert result.upgrade_plan == (
+            {
+                "recipe": "python-l0-baseline",
+                "from_version": 1,
+                "to_version": 2,
+                "tools": {
+                    "pytest": {"from": "9.0", "to": "9.1.1"},
+                    "ruff": {"from": "0.12.0", "to": "0.12.4"},
+                },
+            },
+        )
+        assert json.loads(output.read_text(encoding="utf-8")) == result.to_dict()
+        assert bundled.read_bytes() == before_bundled
+        assert project_policy.read_bytes() == before_policy
+        payload = output.read_text(encoding="utf-8")
+        assert str(repository) not in payload
+        assert "private" not in payload.lower()
+
+
+@pytest.mark.parametrize(
+    ("version", "expected_code"),
+    [
+        (1, "recipe_version_not_incremented"),
+        (0, "recipe_version_invalid"),
+    ],
+)
+def test_refresh_rejects_unversioned_or_regressive_changes(
+    version: int,
+    expected_code: str,
+) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        proposed_recipe = _recipe(
+            version=max(version, 1),
+            reviewed_at="2026-07-28",
+            tool_versions={"pytest": "9.1.1", "ruff": "0.12.0"},
+        )
+        if version == 0:
+            proposed_recipe["version"] = 0
+        proposed = _write_catalog(root / "proposed.yaml", [proposed_recipe])
+        output = root / "refresh.json"
+
+        result = RecipeCatalog().refresh_preview(
+            proposed_catalog=proposed,
+            output_path=output,
+            today=date(2026, 7, 28),
+        )
+
+        assert result.status == "invalid"
+        assert expected_code in {
+            finding.code for finding in result.validation.findings
+        }
+        assert result.upgrade_plan == ()
+
+
+def test_refresh_rejects_removing_a_bundled_recipe() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        proposed = _write_catalog(root / "proposed.yaml", [])
+        output = root / "refresh.json"
+
+        result = RecipeCatalog().refresh_preview(
+            proposed_catalog=proposed,
+            output_path=output,
+            today=date(2026, 7, 28),
+        )
+
+        assert result.status == "invalid"
+        assert "recipe_removed" in {
+            finding.code for finding in result.validation.findings
+        }
+
+
+def test_recipe_requires_complete_metadata() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        recipe = _recipe(version=1)
+        recipe["report_formats"] = []
+        path = _write_catalog(Path(directory) / "incomplete.yaml", [recipe])
+
+        with pytest.raises(ValueError, match="report_formats"):
+            RecipeCatalog().audit(catalog_path=path)
+
+
+def test_approved_harness_plan_keeps_pinned_recipe_after_refresh() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        setup = HarnessSetup(recipe_catalog=RecipeCatalog())
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+        proposed = _write_catalog(
+            root / "proposed.yaml",
+            [_recipe(version=2, reviewed_at="2026-07-28")],
+        )
+
+        RecipeCatalog().refresh_preview(
+            proposed_catalog=proposed,
+            output_path=root / "refresh.json",
+            today=date(2026, 7, 28),
+        )
+
+        assert approved.recipe_versions == (("python-l0-baseline", 1),)
+        assert json.loads(
+            (root / "approved-plan.json").read_text(encoding="utf-8")
+        )["recipe_versions"] == [
+            {"name": "python-l0-baseline", "version": 1}
+        ]
+
+
+def test_cli_audit_and_refresh_match_catalog_results(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        proposed = _write_catalog(
+            root / "proposed.yaml",
+            [_recipe(version=2, reviewed_at="2026-07-28")],
+        )
+        output = root / "refresh.json"
+
+        audit_code = cli_main(["recipes", "audit"])
+        audit = json.loads(capsys.readouterr().out)
+        refresh_code = cli_main(
+            [
+                "recipes",
+                "refresh",
+                "--proposed",
+                str(proposed),
+                "--output",
+                str(output),
+            ]
+        )
+        refresh = json.loads(capsys.readouterr().out)
+
+        assert audit_code == 0
+        assert audit["status"] == "ok"
+        assert refresh_code == 0
+        assert refresh["status"] == "review_required"
+        assert refresh == json.loads(output.read_text(encoding="utf-8"))
+
+
+def test_refresh_skill_routes_to_public_preview_without_private_data() -> None:
+    bundled = (
+        TOOL_ROOT / "skills" / "refresh-harness-recipes" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    project = (
+        TOOL_ROOT.parent.parent
+        / ".codex"
+        / "skills"
+        / "refresh-harness-recipes"
+        / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert bundled == project
+    assert "aiwb recipes audit" in bundled
+    assert "aiwb recipes refresh" in bundled
+    assert "official sources" in bundled
+    assert "private repository" in bundled
+    assert "does not mutate" in bundled
+
+
+def _recipe(
+    *,
+    version: int,
+    reviewed_at: str = "2026-07-01",
+    source: str = "https://docs.pytest.org/en/stable/",
+    verification_state: str = "verified",
+    tool_versions=None,
+):
+    return {
+        "name": "python-l0-baseline",
+        "version": version,
+        "official_sources": [source],
+        "reviewed_at": reviewed_at,
+        "applicability": ["language:python", "tier:l0"],
+        "alternatives": ["preserve-project-tools"],
+        "cost": "low",
+        "migration_risk": "low",
+        "report_formats": ["junit-xml", "coverage-xml"],
+        "verification_state": verification_state,
+        "tool_versions": tool_versions
+        or {"pytest": "9.0", "ruff": "0.12.0"},
+    }
+
+
+def _write_catalog(path: Path, recipes) -> Path:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "kind": "aiwb.recipe-catalog",
+                "recipes": recipes,
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _python_repository(root: Path) -> Path:
+    repository = root / "project"
+    (repository / "tests").mkdir(parents=True)
+    (repository / "pyproject.toml").write_text(
+        "[tool.pytest.ini_options]\n"
+        "testpaths = ['tests']\n",
+        encoding="utf-8",
+    )
+    return repository


### PR DESCRIPTION
## Summary
- add a bundled versioned public Recipe Catalog with complete source, review, applicability, alternatives, cost, migration, report, verification, and tool-version metadata
- resolve project overrides before configured private Catalogs before bundled public Recipes, with explicit same-layer conflicts and verified-only formal gates
- pin resolved Recipe versions in Harness Plan approval artifacts
- add deterministic `aiwb recipes audit` and source-backed public refresh previews with validation evidence, version rules, reviewable diffs, and separate tool upgrade plans
- add a bounded refresh Skill that excludes private repository data and never mutates approved projects or bundled Catalogs

## Test plan
- `PYTHONPYCACHEPREFIX=/tmp/aiwb-issue20-final-full PYTHONDONTWRITEBYTECODE=1 /tmp/aiwb-final-test-venv/bin/python -m pytest -q` -> 196 passed
- focused Catalog/Harness/Apply/Skill suite -> 50 passed
- compileall, Skill mirror, diff checks, and setup.cfg package-data parsing passed
- post-commit Recipe Catalog suite -> 13 passed

## Packaging note
- `aiwb = recipes/*.yaml` package data is configured and parsed successfully; runtime tests load the bundled Catalog from package layout.
- A local wheel build was not available because the verification venv lacks the `bdist_wheel` command; no dependency was installed or fetched to bypass that environment limitation.

Closes #20