### PR TITLE
fix: make Harness setup portable

### DIFF
--- a/.codex/skills/setup-ai-workbench/SKILL.md
+++ b/.codex/skills/setup-ai-workbench/SKILL.md
@@ -76,7 +76,9 @@ review. `configured_local` is not pipeline verification.
 
 Once an approved repository flow publishes the configured candidate, use
 `aiwb pipeline verify` with the candidate report, GitHub owner/repository,
-required check names, required artifact names, and an external state directory.
+the approved Harness workflow name, required check names, required artifact
+names, and an external state directory. AI Workbench resolves `gh` from `PATH`;
+`AIWB_GH_BIN` is an explicit override, not a required setup step.
 This is read-only against GitHub. Do not dispatch a workflow, inspect secret
 values, change required checks, or accept a green result for another commit.
 Report `pipeline_pending`, `verification_failed`, or `verified` exactly as

--- a/.github/workflows/aiwb-harness.yml
+++ b/.github/workflows/aiwb-harness.yml
@@ -55,3 +55,43 @@ jobs:
             tools/agent-orchestrator/artifacts/pipeline-evidence.txt
           if-no-files-found: error
           retention-days: 14
+
+  portability:
+    name: portability (${{ matrix.os }}, Python ${{ matrix.python }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            python: "3.11"
+          - os: ubuntu-latest
+            python: "3.9"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: tools/agent-orchestrator
+    steps:
+      - name: Checkout exact commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: tools/agent-orchestrator/setup.cfg
+
+      - name: Install Harness dependencies
+        run: python -m pip install -e ".[test]"
+
+      - name: Run portability smoke
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+          PYTHONPYCACHEPREFIX: ${{ runner.temp }}/aiwb-pycache
+        run: |
+          python -m pytest -q \
+            tests/test_harness_setup.py \
+            tests/test_harness_apply.py \
+            tests/test_recipe_catalog.py \
+            tests/test_github_pipeline.py

--- a/tools/agent-orchestrator/README.md
+++ b/tools/agent-orchestrator/README.md
@@ -86,6 +86,7 @@ repository flow, read its GitHub Actions state without dispatching a workflow:
 aiwb pipeline verify \
   --candidate-report /path/to/configured-local-report.json \
   --owner owner --repository repository \
+  --workflow-name "AI Workbench Harness" \
   --required-check harness \
   --required-artifact harness-evidence \
   --state-dir /path/outside/repository/state
@@ -98,7 +99,10 @@ becomes `pipeline_pending`; only successful required checks and artifacts for
 the exact candidate commit can become `verified`. Stale green commits,
 failures, cancellation, missing or expired artifacts, and missing terminal
 checks remain explicitly non-verified. Every observed retry and first failure
-stays in the append-only external report.
+stays in the append-only external report. The approved Harness workflow must
+always be selected with `--workflow-name`; required gates are matched to jobs
+from that workflow run. Unrelated workflow runs and commit-level checks remain
+visible Evidence but cannot control verification.
 
 This repository dogfoods the Adapter through
 `.github/workflows/aiwb-harness.yml`. The workflow uses pinned Actions commits,

--- a/tools/agent-orchestrator/setup.cfg
+++ b/tools/agent-orchestrator/setup.cfg
@@ -16,7 +16,9 @@ install_requires =
 
 [options.extras_require]
 test =
-    pytest>=9.0
+    pytest>=8.3,<9; python_version < "3.10"
+    pytest>=9.0; python_version >= "3.10"
+    pytest-cov>=5,<7
 
 [options.packages.find]
 where = src

--- a/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
+++ b/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
@@ -76,7 +76,9 @@ review. `configured_local` is not pipeline verification.
 
 Once an approved repository flow publishes the configured candidate, use
 `aiwb pipeline verify` with the candidate report, GitHub owner/repository,
-required check names, required artifact names, and an external state directory.
+the approved Harness workflow name, required check names, required artifact
+names, and an external state directory. AI Workbench resolves `gh` from `PATH`;
+`AIWB_GH_BIN` is an explicit override, not a required setup step.
 This is read-only against GitHub. Do not dispatch a workflow, inspect secret
 values, change required checks, or accept a green result for another commit.
 Report `pipeline_pending`, `verification_failed`, or `verified` exactly as

--- a/tools/agent-orchestrator/src/aiwb/_harness_apply.py
+++ b/tools/agent-orchestrator/src/aiwb/_harness_apply.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import configparser
 import hashlib
 import json
 import os
@@ -17,8 +18,16 @@ import yaml
 
 from .evidence import EvidenceReference, EvidenceStore
 
+try:
+    import tomllib
+except ImportError:  # pragma: no cover - Python 3.9 and 3.10
+    import tomli as tomllib
+
 if TYPE_CHECKING:
     from .harness_setup import HarnessPlan
+
+_POETRY_VERSION = "2.1.3"
+_UV_VERSION = "0.8.4"
 
 
 @dataclass(frozen=True)
@@ -369,8 +378,6 @@ def apply_python_l0(
             "commit",
             "-m",
             "chore: configure Python L0 Harness",
-            "-m",
-            "Co-authored-by: TRAE CLI <noreply@bytedance.com>",
         )
     candidate_commit = _git(worktree, "rev-parse", "HEAD").stdout.strip()
     evidence = []
@@ -538,10 +545,11 @@ def _render_projections(
         rendered = shlex.join(canonical)
         canonical_lines.append(f"- `{rendered}`")
         pipeline_lines.append(f"      - run: {rendered}")
+    python_version, install_steps = _python_pipeline_setup(repository, selected)
     workflow = {
         "schema_version": 1,
         "status": "approved",
-        "project": {"root": str(repository), "trusted": True},
+        "project": {"root": ".", "trusted": True},
         "capabilities": {"commands": approved_commands, "skills": {}},
         "harness": {"allowed_kubernetes_contexts": [], "profiles": {}},
         "images": {"profiles": {}},
@@ -571,6 +579,10 @@ def _render_projections(
         "    runs-on: ubuntu-latest\n"
         "    steps:\n"
         "      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2\n"
+        "      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0\n"
+        "        with:\n"
+        f'          python-version: "{python_version}"\n'
+        + install_steps
         + "\n".join(pipeline_lines)
         + "\n"
     )
@@ -628,6 +640,122 @@ def _render_projections(
         ),
         tuple(probe_commands),
     )
+
+
+def _python_pipeline_setup(
+    repository: Path,
+    selected: Sequence[object],
+) -> Tuple[str, str]:
+    target_paths = tuple(
+        sorted({str(candidate.working_directory) for candidate in selected})
+    )
+    versions = {
+        version
+        for target_path in target_paths
+        if (version := _declared_python_version(repository / target_path))
+    }
+    if len(versions) > 1:
+        raise ValueError(
+            "selected Python targets require different interpreter versions"
+        )
+    python_version = next(iter(versions), "3.11")
+    rendered_steps = []
+    for target_path in target_paths:
+        commands = _python_install_commands(repository / target_path)
+        rendered_steps.append(
+            "      - name: Install Harness dependencies\n"
+            f"        working-directory: {json.dumps(target_path)}\n"
+            "        run: |\n"
+            + "".join(f"          {shlex.join(command)}\n" for command in commands)
+        )
+    return python_version, "".join(rendered_steps)
+
+
+def _declared_python_version(target: Path) -> str:
+    version_file = target / ".python-version"
+    if version_file.is_file():
+        lines = version_file.read_text(encoding="utf-8").splitlines()
+        value = lines[0].strip() if lines else ""
+        match = re.match(r"^(\d+\.\d+)", value)
+        if match:
+            return match.group(1)
+
+    constraint = ""
+    pyproject = target / "pyproject.toml"
+    if pyproject.is_file():
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        project = data.get("project", {})
+        if isinstance(project, dict):
+            value = project.get("requires-python")
+            if isinstance(value, str):
+                constraint = value
+    setup_cfg = target / "setup.cfg"
+    if not constraint and setup_cfg.is_file():
+        parser = configparser.ConfigParser()
+        parser.read(setup_cfg, encoding="utf-8")
+        constraint = parser.get("options", "python_requires", fallback="")
+    match = re.search(r"(\d+)\.(\d+)", constraint)
+    return f"{match.group(1)}.{match.group(2)}" if match else ""
+
+
+def _python_install_commands(target: Path) -> Tuple[Tuple[str, ...], ...]:
+    if (target / "uv.lock").is_file():
+        return (
+            ("python", "-m", "pip", "install", f"uv=={_UV_VERSION}"),
+            ("uv", "sync", "--locked", "--all-extras", "--dev"),
+            (
+                "bash",
+                "-c",
+                'echo "$PWD/.venv/bin" >> "$GITHUB_PATH"',
+            ),
+        )
+    if (target / "poetry.lock").is_file():
+        return (
+            (
+                "python",
+                "-m",
+                "pip",
+                "install",
+                f"poetry=={_POETRY_VERSION}",
+            ),
+            ("poetry", "config", "virtualenvs.create", "false", "--local"),
+            ("poetry", "install", "--no-interaction"),
+        )
+    for name in (
+        "requirements-dev.txt",
+        "requirements-test.txt",
+        "requirements.txt",
+    ):
+        if (target / name).is_file():
+            return (("python", "-m", "pip", "install", "-r", name),)
+
+    extra = _python_test_extra(target)
+    package = f".[{extra}]" if extra else "."
+    return (("python", "-m", "pip", "install", "-e", package),)
+
+
+def _python_test_extra(target: Path) -> str:
+    pyproject = target / "pyproject.toml"
+    if pyproject.is_file():
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        project = data.get("project", {})
+        optional = (
+            project.get("optional-dependencies", {})
+            if isinstance(project, dict)
+            else {}
+        )
+        if isinstance(optional, dict):
+            for name in ("test", "tests", "dev"):
+                if name in optional:
+                    return name
+    setup_cfg = target / "setup.cfg"
+    if setup_cfg.is_file():
+        parser = configparser.ConfigParser()
+        parser.read(setup_cfg, encoding="utf-8")
+        for name in ("test", "tests", "dev"):
+            if parser.has_option("options.extras_require", name):
+                return name
+    return ""
 
 
 def _wrapper_content(

--- a/tools/agent-orchestrator/src/aiwb/_python_setup.py
+++ b/tools/agent-orchestrator/src/aiwb/_python_setup.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import configparser
 import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Optional, Tuple
@@ -427,7 +426,7 @@ def _capabilities(
         _capability(
             "unit",
             "keep" if has_pytest else "adopt",
-            (sys.executable, "-m", "pytest", "-q"),
+            ("python3", "-m", "pytest", "-q"),
             "pytest project metadata" if has_pytest else "Python target structure",
             "high" if has_pytest else "medium",
             "Preserve the existing Pytest path."
@@ -438,9 +437,9 @@ def _capabilities(
             "lint",
             "keep" if has_flake8 or has_ruff else "adopt",
             (
-                (sys.executable, "-m", "flake8", ".")
+                ("python3", "-m", "flake8", ".")
                 if has_flake8
-                else (sys.executable, "-m", "ruff", "check", ".")
+                else ("python3", "-m", "ruff", "check", ".")
             ),
             (
                 "Flake8 project metadata"
@@ -460,9 +459,9 @@ def _capabilities(
             "format",
             "keep" if has_black or has_ruff else "adopt",
             (
-                (sys.executable, "-m", "black", "--check", ".")
+                ("python3", "-m", "black", "--check", ".")
                 if has_black
-                else (sys.executable, "-m", "ruff", "format", "--check", ".")
+                else ("python3", "-m", "ruff", "format", "--check", ".")
             ),
             (
                 "Black project metadata"
@@ -482,9 +481,9 @@ def _capabilities(
             "typecheck",
             "keep" if type_tool else "adopt",
             (
-                (sys.executable, "-m", type_tool, ".")
+                ("python3", "-m", type_tool, ".")
                 if type_tool
-                else (sys.executable, "-m", "mypy", ".")
+                else ("python3", "-m", "mypy", ".")
             ),
             f"{type_tool} project metadata" if type_tool else "Python target structure",
             "high" if type_tool else "low",
@@ -496,7 +495,7 @@ def _capabilities(
             "coverage",
             "augment" if has_coverage else "adopt",
             (
-                sys.executable,
+                "python3",
                 "-m",
                 "pytest",
                 "--cov",
@@ -521,7 +520,7 @@ def _capabilities(
             _capability(
                 "ruff_lint_migration",
                 "migrate_later",
-                (sys.executable, "-m", "ruff", "check", "."),
+                ("python3", "-m", "ruff", "check", "."),
                 "Flake8 and Ruff project metadata",
                 "high",
                 "Keep Flake8 working; evaluate Ruff consolidation separately.",
@@ -532,7 +531,7 @@ def _capabilities(
             _capability(
                 "ruff_format_migration",
                 "migrate_later",
-                (sys.executable, "-m", "ruff", "format", "--check", "."),
+                ("python3", "-m", "ruff", "format", "--check", "."),
                 "Black and Ruff project metadata",
                 "high",
                 "Keep Black working; evaluate Ruff consolidation separately.",

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -132,6 +132,7 @@ def _build_parser() -> argparse.ArgumentParser:
     pipeline_verify.add_argument("--candidate-report", required=True, type=Path)
     pipeline_verify.add_argument("--owner", required=True)
     pipeline_verify.add_argument("--repository", required=True)
+    pipeline_verify.add_argument("--workflow-name", required=True)
     pipeline_verify.add_argument(
         "--required-check",
         action="append",
@@ -492,12 +493,13 @@ def _run_pipeline(options: argparse.Namespace) -> int:
         repository=options.repository,
         candidate=HarnessApplyResult.from_dict(value),
         required_checks=tuple(options.required_check),
+        workflow_name=options.workflow_name,
         required_artifacts=tuple(options.required_artifact),
         missing_variables=tuple(
             _named_values(options.missing_variable, "missing variable")
         ),
     )
-    executable = os.environ.get("AIWB_GH_BIN", "/usr/bin/gh")
+    executable = os.environ.get("AIWB_GH_BIN") or None
     result = HarnessSetup().verify_pipeline(
         request,
         adapter=GitHubActionsAdapter(

--- a/tools/agent-orchestrator/src/aiwb/github_pipeline.py
+++ b/tools/agent-orchestrator/src/aiwb/github_pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -17,6 +18,7 @@ class GitHubPipelineRequest:
     owner: str
     repository: str
     candidate: HarnessApplyResult
+    workflow_name: str
     required_checks: Tuple[str, ...]
     required_artifacts: Tuple[str, ...] = ()
     missing_variables: Tuple[Tuple[str, str], ...] = ()
@@ -123,7 +125,7 @@ class GitHubActionsAdapter:
         _validate_request(request)
         raw_runs = tuple(self._source.workflow_runs(request))
         raw_checks = tuple(self._source.check_runs(request))
-        exact_runs = tuple(
+        commit_runs = tuple(
             run for run in raw_runs if str(run.get("head_sha", "")) == request.commit
         )
         evidence = [
@@ -149,7 +151,7 @@ class GitHubActionsAdapter:
                     ),
                 )
             )
-        if not exact_runs:
+        if not commit_runs:
             blockers.append(
                 IntakeBlocker(
                     code="exact_commit_missing",
@@ -162,12 +164,38 @@ class GitHubActionsAdapter:
                     ),
                 )
             )
-            return _result(request, evidence, blockers)
+            return _result(request, evidence, blockers, selected_run_ids=())
+        exact_runs = tuple(
+            run
+            for run in commit_runs
+            if str(run.get("name", "")) == request.workflow_name
+        )
+        if not exact_runs:
+            blockers.append(
+                IntakeBlocker(
+                    code="workflow_missing",
+                    message=(
+                        "No exact-commit GitHub Actions run matches workflow "
+                        f"{request.workflow_name!r}."
+                    ),
+                    action=(
+                        "Confirm the Harness workflow name and publish the exact "
+                        "candidate through that approved workflow."
+                    ),
+                )
+            )
+            return _result(request, evidence, blockers, selected_run_ids=())
 
         exact_runs = tuple(sorted(exact_runs, key=_attempt_key))
+        selected_run_ids = tuple(
+            str(_integer(run.get("id"), "workflow run id"))
+            for run in exact_runs
+        )
+        jobs_by_run_id = {}
         for run in exact_runs:
             run_id = _integer(run.get("id"), "workflow run id")
             jobs = tuple(self._source.run_jobs(request, run_id))
+            jobs_by_run_id[run_id] = jobs
             evidence.extend(
                 _job_evidence(job, request.commit, run)
                 for job in jobs
@@ -178,23 +206,18 @@ class GitHubActionsAdapter:
                 for artifact in artifacts
             )
 
-        exact_checks = tuple(
-            check
-            for check in raw_checks
-            if str(check.get("head_sha", "")) == request.commit
-        )
         latest_run = exact_runs[-1]
         latest_run_id = _integer(latest_run.get("id"), "workflow run id")
         run_status = str(latest_run.get("status", ""))
         run_conclusion = str(latest_run.get("conclusion") or "")
         pending = run_status != "completed"
-        check_by_name = {
-            str(check.get("name", "")): check
-            for check in exact_checks
+        selected_job_by_name = {
+            str(job.get("name", "")): job
+            for job in jobs_by_run_id[latest_run_id]
         }
         for required in request.required_checks:
-            check = check_by_name.get(required)
-            if check is None:
+            selected_job = selected_job_by_name.get(required)
+            if selected_job is None:
                 if not pending:
                     blockers.append(
                         IntakeBlocker(
@@ -207,8 +230,8 @@ class GitHubActionsAdapter:
                         )
                     )
                 continue
-            status = str(check.get("status", ""))
-            conclusion = str(check.get("conclusion") or "")
+            status = str(selected_job.get("status", ""))
+            conclusion = str(selected_job.get("conclusion") or "")
             if status != "completed":
                 pending = True
             elif conclusion != "success":
@@ -257,7 +280,13 @@ class GitHubActionsAdapter:
                             ),
                         )
                     )
-        return _result(request, evidence, blockers, pending=pending)
+        return _result(
+            request,
+            evidence,
+            blockers,
+            pending=pending,
+            selected_run_ids=selected_run_ids,
+        )
 
 
 class GhApiGitHubSource:
@@ -265,15 +294,23 @@ class GhApiGitHubSource:
 
     def __init__(
         self,
-        executable: str = "/usr/bin/gh",
+        executable: str | None = None,
         environment: Mapping[str, str] | None = None,
     ) -> None:
-        self._executable = executable
         self._environment = (
             dict(environment)
             if environment is not None
             else dict(os.environ)
         )
+        resolved = executable or shutil.which(
+            "gh",
+            path=self._environment.get("PATH", os.defpath),
+        )
+        if not resolved:
+            raise ValueError(
+                "GitHub CLI 'gh' was not found on PATH; install it or set AIWB_GH_BIN"
+            )
+        self._executable = resolved
 
     def workflow_runs(
         self,
@@ -426,18 +463,25 @@ def _result(
     blockers: Sequence[IntakeBlocker],
     *,
     pending: bool = False,
+    selected_run_ids: Sequence[str],
 ) -> PipelineVerification:
+    selected = set(selected_run_ids)
     attempts = sorted(
         {
             item.attempt
             for item in evidence
-            if item.kind == "run" and not item.stale
+            if item.kind == "run"
+            and not item.stale
+            and item.identifier in selected
         }
     )
     conclusions = {
         item.conclusion
         for item in evidence
-        if item.kind == "run" and not item.stale and item.conclusion
+        if item.kind == "run"
+        and not item.stale
+        and item.identifier in selected
+        and item.conclusion
     }
     flaky = "failure" in conclusions and "success" in conclusions
     if blockers:
@@ -542,6 +586,8 @@ def _validate_request(request: GitHubPipelineRequest) -> None:
         raise ValueError("Pipeline verification requires configured_local candidate")
     if not request.owner or not request.repository:
         raise ValueError("GitHub owner and repository are required")
+    if not request.workflow_name.strip():
+        raise ValueError("GitHub workflow_name is required")
     if len(request.commit) != 40:
         raise ValueError("candidate commit must be a full Git commit SHA")
     if not request.required_checks:
@@ -555,8 +601,8 @@ def _validate_request(request: GitHubPipelineRequest) -> None:
 
 def _attempt_key(run: Mapping[str, object]) -> Tuple[int, int]:
     return (
-        _integer(run.get("run_attempt", 1), "run attempt"),
         _integer(run.get("id"), "workflow run id"),
+        _integer(run.get("run_attempt", 1), "run attempt"),
     )
 
 

--- a/tools/agent-orchestrator/src/aiwb/project.py
+++ b/tools/agent-orchestrator/src/aiwb/project.py
@@ -114,7 +114,7 @@ class ProjectPolicy:
         root = project.get("root")
         if not isinstance(root, str) or not root:
             raise ProjectConfigError("project policy root must be a non-empty string")
-        repository = Path(root).expanduser().resolve()
+        repository = _resolve_project_root(config_path, root)
 
         capabilities = data.get("capabilities")
         if not isinstance(capabilities, dict):
@@ -856,7 +856,7 @@ class ProjectDoctor:
         )
         root_value = project.get("root")
         repository = (
-            Path(root_value).expanduser().resolve()
+            _resolve_project_root(config_path, root_value)
             if isinstance(root_value, str) and root_value
             else None
         )
@@ -1025,6 +1025,18 @@ class ProjectDoctor:
 def _read_small_text(path: Path, limit: int = 1024 * 1024) -> str:
     with path.open("r", encoding="utf-8", errors="replace") as source:
         return source.read(limit)
+
+
+def _resolve_project_root(config_path: Path, root: str) -> Path:
+    value = Path(root).expanduser()
+    if value.is_absolute():
+        return value.resolve()
+    base = (
+        config_path.parent.parent
+        if config_path.parent.name == ".ai-workbench"
+        else config_path.parent
+    )
+    return (base / value).resolve()
 
 
 def _string_mapping(value: object) -> Mapping[str, str]:

--- a/tools/agent-orchestrator/src/aiwb/recipe_catalog.py
+++ b/tools/agent-orchestrator/src/aiwb/recipe_catalog.py
@@ -121,6 +121,18 @@ class RecipeRefreshPreview:
             "output_path": self.output_path,
         }
 
+    def artifact_dict(self) -> Mapping[str, object]:
+        validation = dict(self.validation.to_dict())
+        validation.pop("catalog_path", None)
+        return {
+            "status": self.status,
+            "current_catalog_digest": self.current_catalog_digest,
+            "proposed_catalog_digest": self.proposed_catalog_digest,
+            "changes": [dict(item) for item in self.changes],
+            "upgrade_plan": [dict(item) for item in self.upgrade_plan],
+            "validation": validation,
+        }
+
 
 class RecipeCatalog:
     """Resolve layered versioned Recipes and preview source-backed refreshes."""
@@ -363,7 +375,7 @@ class RecipeCatalog:
             validation=proposed,
             output_path=str(output_path),
         )
-        _write_json_atomically(output_path, result.to_dict())
+        _write_json_atomically(output_path, result.artifact_dict())
         return result
 
 

--- a/tools/agent-orchestrator/tests/test_github_pipeline.py
+++ b/tools/agent-orchestrator/tests/test_github_pipeline.py
@@ -195,13 +195,16 @@ def test_expired_required_artifact_is_non_verified_and_visible() -> None:
     )
 
 
-def test_completed_run_with_missing_required_check_is_non_verified() -> None:
+def test_completed_run_with_missing_required_job_is_non_verified() -> None:
     source = FixtureSource(
         runs=(
             _run(10, commit=COMMIT, status="completed", conclusion="success"),
         ),
         jobs=(
-            _job(10, 100, status="completed", conclusion="success"),
+            {
+                **_job(10, 100, status="completed", conclusion="success"),
+                "name": "docs",
+            },
         ),
         checks=(),
         artifacts=(
@@ -269,6 +272,124 @@ def test_flaky_retry_preserves_first_failure_and_successful_retry() -> None:
     assert result.flaky is True
 
 
+def test_newer_workflow_run_wins_when_older_run_has_higher_attempt() -> None:
+    source = FixtureSource(
+        runs=(
+            _run(
+                10,
+                commit=COMMIT,
+                attempt=2,
+                status="completed",
+                conclusion="failure",
+            ),
+            _run(
+                11,
+                commit=COMMIT,
+                attempt=1,
+                status="completed",
+                conclusion="success",
+            ),
+        ),
+        jobs=(
+            _job(10, 100, attempt=2, status="completed", conclusion="failure"),
+            _job(11, 101, attempt=1, status="completed", conclusion="success"),
+        ),
+        checks=(
+            _check("harness", commit=COMMIT, status="completed", conclusion="success"),
+        ),
+        artifacts=(
+            _artifact(11, "harness-evidence", expired=False),
+        ),
+    )
+
+    result = GitHubActionsAdapter(source).verify(_request())
+
+    assert result.status == "verified"
+    assert result.blockers == ()
+
+
+def test_unrelated_workflow_cannot_control_harness_verification() -> None:
+    source = FixtureSource(
+        runs=(
+            _run(
+                10,
+                commit=COMMIT,
+                status="completed",
+                conclusion="success",
+                name="AI Workbench Harness",
+            ),
+            _run(
+                20,
+                commit=COMMIT,
+                status="completed",
+                conclusion="failure",
+                name="Documentation",
+            ),
+        ),
+        jobs=(
+            _job(10, 100, status="completed", conclusion="success"),
+            {
+                **_job(20, 200, status="completed", conclusion="failure"),
+                "name": "docs",
+            },
+        ),
+        checks=(
+            _check("harness", commit=COMMIT, status="completed", conclusion="success"),
+        ),
+        artifacts=(
+            _artifact(10, "harness-evidence", expired=False),
+        ),
+    )
+
+    result = GitHubActionsAdapter(source).verify(
+        _request(workflow_name="AI Workbench Harness")
+    )
+
+    assert result.status == "verified"
+    assert result.retry_count == 0
+    assert result.flaky is False
+    assert any(
+        item.kind == "run" and item.name == "Documentation"
+        for item in result.evidence
+    )
+
+
+def test_unrelated_commit_check_cannot_satisfy_selected_workflow_gate() -> None:
+    source = FixtureSource(
+        runs=(
+            _run(
+                10,
+                commit=COMMIT,
+                status="completed",
+                conclusion="success",
+            ),
+        ),
+        jobs=(
+            {
+                **_job(10, 100, status="completed", conclusion="success"),
+                "name": "docs",
+            },
+        ),
+        checks=(
+            _check("harness", commit=COMMIT, status="completed", conclusion="success"),
+        ),
+    )
+
+    result = GitHubActionsAdapter(source).verify(_request())
+
+    assert result.status == "verification_failed"
+    assert [blocker.code for blocker in result.blockers] == [
+        "required_check_missing"
+    ]
+
+
+def test_pipeline_verification_requires_explicit_workflow_identity() -> None:
+    request = _request(workflow_name="")
+
+    with pytest.raises(ValueError, match="workflow_name"):
+        GitHubActionsAdapter(FixtureSource()).verify(request)
+
+
 def test_adapter_rejects_non_configured_local_input() -> None:
     configured = replace_apply_status("failed_local")
     request = _request(configured=configured)
@@ -296,6 +417,7 @@ def test_missing_variable_reports_only_name_and_purpose() -> None:
         owner="blackfaced",
         repository="ai-workbench",
         candidate=replace_apply_status("configured_local"),
+        workflow_name="AI Workbench Harness",
         required_checks=("harness",),
         required_artifacts=("harness-evidence",),
         missing_variables=(("PACKAGE_TOKEN", "read private test dependency"),),
@@ -445,6 +567,22 @@ def test_gh_source_uses_only_side_effect_free_get_requests() -> None:
         assert "/branches/" not in serialized
 
 
+def test_gh_source_resolves_the_cli_from_path() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        executable = root / "gh"
+        executable.write_text(
+            f"#!{sys.executable}\n"
+            "import json\n"
+            "print(json.dumps({'workflow_runs': []}))\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        source = GhApiGitHubSource(environment={"PATH": str(root)})
+
+        assert source.workflow_runs(_request()) == ()
+
+
 def test_pipeline_cli_reads_candidate_report_and_returns_pending(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
@@ -499,6 +637,8 @@ def test_pipeline_cli_reads_candidate_report_and_returns_pending(
                 "blackfaced",
                 "--repository",
                 "ai-workbench",
+                "--workflow-name",
+                "AI Workbench Harness",
                 "--required-check",
                 "harness",
                 "--required-artifact",
@@ -530,15 +670,25 @@ def test_repository_github_workflow_has_stable_gate_and_pinned_actions() -> None
     assert "workflow_dispatch" not in workflow
     assert "actions/checkout@v4" not in workflow
     assert "actions/setup-python@v5" not in workflow
+    assert "macos-latest" in workflow
+    assert 'python: "3.9"' in workflow
+    assert "tests/test_harness_setup.py" in workflow
+    assert "tests/test_harness_apply.py" in workflow
+    assert "tests/test_recipe_catalog.py" in workflow
+    assert "tests/test_github_pipeline.py" in workflow
 
 
-def _request(configured=None) -> GitHubPipelineRequest:
+def _request(
+    configured=None,
+    workflow_name: str = "AI Workbench Harness",
+) -> GitHubPipelineRequest:
     return GitHubPipelineRequest(
         owner="blackfaced",
         repository="ai-workbench",
         candidate=configured or replace_apply_status("configured_local"),
         required_checks=("harness",),
         required_artifacts=("harness-evidence",),
+        workflow_name=workflow_name,
     )
 
 
@@ -565,6 +715,7 @@ def _run(
     status: str,
     conclusion,
     attempt: int = 1,
+    name: str = "AI Workbench Harness",
 ):
     return {
         "id": run_id,
@@ -573,7 +724,7 @@ def _run(
         "conclusion": conclusion,
         "run_attempt": attempt,
         "html_url": f"https://github.test/runs/{run_id}",
-        "name": "AI Workbench Harness",
+        "name": name,
         "event": "push",
     }
 

--- a/tools/agent-orchestrator/tests/test_harness_apply.py
+++ b/tools/agent-orchestrator/tests/test_harness_apply.py
@@ -14,7 +14,12 @@ import yaml
 TOOL_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(TOOL_ROOT / "src"))
 
-from aiwb import EvidenceStore, HarnessSetup, HarnessSetupRequest  # noqa: E402
+from aiwb import (  # noqa: E402
+    EvidenceStore,
+    HarnessSetup,
+    HarnessSetupRequest,
+    ProjectPolicy,
+)
 from aiwb.cli import main as cli_main  # noqa: E402
 
 
@@ -105,10 +110,25 @@ def test_approved_python_l0_apply_configures_isolated_candidate() -> None:
         )
         canonical = ["bash", ".ai-workbench/commands/unit.sh"]
         assert workflow["capabilities"]["commands"]["unit"]["argv"] == canonical
+        assert workflow["project"]["root"] == "."
+        assert ProjectPolicy.load(
+            worktree / ".ai-workbench" / "workflow.yaml"
+        ).repository == worktree.resolve()
+        unit_wrapper = (
+            worktree / ".ai-workbench" / "commands" / "unit.sh"
+        ).read_text(encoding="utf-8")
+        assert sys.executable not in unit_wrapper
+        assert "python3 -m pytest" in unit_wrapper
         pipeline = (
             worktree / ".github" / "workflows" / "aiwb-harness.yml"
         ).read_text(encoding="utf-8")
         assert "bash .ai-workbench/commands/unit.sh" in pipeline
+        assert (
+            "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
+            in pipeline
+        )
+        assert 'python-version: "3.9"' in pipeline
+        assert "python -m pip install -e '.[test]'" in pipeline
         assert (
             "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
             in pipeline
@@ -156,6 +176,80 @@ def test_approved_python_l0_apply_configures_isolated_candidate() -> None:
             primary_branch,
             check=False,
         ).returncode != 0
+        candidate_message = _git(
+            worktree,
+            "show",
+            "-s",
+            "--format=%B",
+            result.candidate_commit,
+        ).stdout.lower()
+        assert "trae" not in candidate_message
+        assert "bytedance" not in candidate_message
+
+
+@pytest.mark.parametrize(
+    ("lockfile", "expected_commands"),
+    (
+        (
+            "poetry.lock",
+            (
+                "python -m pip install poetry==2.1.3",
+                "poetry config virtualenvs.create false --local",
+                "poetry install --no-interaction",
+            ),
+        ),
+        (
+            "uv.lock",
+            (
+                "python -m pip install uv==0.8.4",
+                "uv sync --locked --all-extras --dev",
+                "GITHUB_PATH",
+            ),
+        ),
+    ),
+)
+def test_apply_preview_derives_locked_pipeline_setup_from_project_metadata(
+    lockfile: str,
+    expected_commands: tuple[str, ...],
+) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _python_repository(root)
+        (repository / lockfile).write_text(
+            "# fixture lock\n",
+            encoding="utf-8",
+        )
+        _git(repository, "add", lockfile)
+        _git(repository, "commit", "-m", "Add package manager lock")
+        setup = HarnessSetup()
+        plan = setup.plan(
+            HarnessSetupRequest(
+                repository=repository,
+                planning_mode="python-l0",
+            )
+        )
+        approved_plan = setup.approve_plan(
+            plan,
+            approved_by="owner",
+            artifact_path=root / "approved-plan.json",
+        )
+
+        preview = setup.preview_apply(
+            approved_plan,
+            base_commit=_git(repository, "rev-parse", "HEAD").stdout.strip(),
+            state_dir=root / "state",
+            command_names=("unit",),
+        )
+
+        pipeline = next(
+            projection.content
+            for projection in preview.files
+            if projection.path == ".github/workflows/aiwb-harness.yml"
+        )
+        assert 'python-version: "3.9"' in pipeline
+        for command in expected_commands:
+            assert command in pipeline
+        assert "pip install -e" not in pipeline
 
 
 def test_apply_rejects_missing_or_modified_exact_approval_before_worktree() -> None:
@@ -813,16 +907,6 @@ def _python_repository(
             "raise SystemExit(0)\n",
             encoding="utf-8",
         )
-        (repository / "conftest.py").write_text(
-            "from pathlib import Path\n\n"
-            "def pytest_addoption(parser):\n"
-            "    parser.addoption('--cov', action='store', nargs='?', const='.')\n"
-            "    parser.addoption('--cov-report', action='store')\n\n"
-            "def pytest_sessionfinish(session, exitstatus):\n"
-            "    if session.config.getoption('--cov') is not None:\n"
-            "        Path('coverage.xml').write_text('<coverage/>\\n')\n",
-            encoding="utf-8",
-        )
     dependencies = (
         "test = ['pytest>=8', 'pytest-cov>=5', 'ruff==0.12.4', 'mypy==1.17']\n\n"
         if full_l0
@@ -834,6 +918,7 @@ def _python_repository(
         "build-backend = 'setuptools.build_meta'\n\n"
         "[project]\n"
         "name = 'sample'\n\n"
+        "requires-python = '>=3.9'\n\n"
         "[project.optional-dependencies]\n"
         + dependencies
         +

--- a/tools/agent-orchestrator/tests/test_harness_setup.py
+++ b/tools/agent-orchestrator/tests/test_harness_setup.py
@@ -477,7 +477,7 @@ def test_harness_setup_apply_requires_a_planned_explicitly_confirmed_request() -
 
         workflow = repository / ".ai-workbench" / "workflow.yaml"
         assert candidate.state == "candidate"
-        assert candidate.workflow_path == str(workflow)
+        assert Path(candidate.workflow_path) == workflow.resolve()
         assert candidate.workflow_action == "created"
         assert candidate.changed is True
         assert workflow.is_file()

--- a/tools/agent-orchestrator/tests/test_recipe_catalog.py
+++ b/tools/agent-orchestrator/tests/test_recipe_catalog.py
@@ -202,12 +202,16 @@ def test_refresh_preview_is_reviewable_and_never_mutates_bundled_or_project() ->
                 },
             },
         )
-        assert json.loads(output.read_text(encoding="utf-8")) == result.to_dict()
+        artifact = json.loads(output.read_text(encoding="utf-8"))
+        assert artifact == result.artifact_dict()
+        assert result.output_path == str(output.resolve())
+        assert "output_path" not in artifact
+        assert "catalog_path" not in artifact["validation"]
         assert bundled.read_bytes() == before_bundled
         assert project_policy.read_bytes() == before_policy
         payload = output.read_text(encoding="utf-8")
         assert str(repository) not in payload
-        assert "private" not in payload.lower()
+        assert str(root.resolve()) not in payload
 
 
 @pytest.mark.parametrize(
@@ -338,7 +342,30 @@ def test_cli_audit_and_refresh_match_catalog_results(
         assert audit["status"] == "ok"
         assert refresh_code == 0
         assert refresh["status"] == "review_required"
-        assert refresh == json.loads(output.read_text(encoding="utf-8"))
+        artifact = json.loads(output.read_text(encoding="utf-8"))
+        assert {
+            key: refresh[key]
+            for key in (
+                "status",
+                "current_catalog_digest",
+                "proposed_catalog_digest",
+                "changes",
+                "upgrade_plan",
+            )
+        } == {
+            key: artifact[key]
+            for key in (
+                "status",
+                "current_catalog_digest",
+                "proposed_catalog_digest",
+                "changes",
+                "upgrade_plan",
+            )
+        }
+        assert refresh["output_path"] == str(output.resolve())
+        assert "output_path" not in artifact
+        assert "catalog_path" in refresh["validation"]
+        assert "catalog_path" not in artifact["validation"]
 
 
 def test_refresh_skill_routes_to_public_preview_without_private_data() -> None:


### PR DESCRIPTION
## Summary

- make generated Python Harness candidates relocatable and remove private attribution
- resolve `gh` from `PATH` and scope pipeline verification to the approved workflow
- make recipe refresh artifacts path-safe and add bounded macOS/Python 3.9 portability coverage

## Root causes fixed

- generated policy and commands captured planning-host paths
- GitHub verification combined runs from unrelated workflows
- declared Python 3.9 support was incompatible with the test dependency range and untested in CI
- persisted recipe refresh previews contained temporary local paths

## Validation

- `python3 -m pytest -q tests/test_harness_apply.py tests/test_github_pipeline.py` (`36 passed` after review fixes)
- `python3 -m pytest -q` (`203 passed`)
- `python3 -m compileall -q src`
- `git diff --check`
- exact-commit `aiwb pipeline verify --workflow-name "AI Workbench Harness"` (`verified`, no blockers)

## Scope

The larger atomic artifact writer and `IntakeBlocker` identity refactors are intentionally deferred to #41 and #42.
