### PR TITLE
Execute Codex Attempts through the native exec surface (#56)

### DIFF
--- a/tools/agent-orchestrator/README.md
+++ b/tools/agent-orchestrator/README.md
@@ -9,9 +9,13 @@ lease-fenced transitions and Evidence references.
 only agent execution seam. A Driver must validate the frozen
 `AgentHarnessProfile` before external execution and fail closed for unsupported
 driver, model configuration, permissions, capabilities, extensions, paths,
-tools, resource limits or trace coverage. This repository ships a strict fake
-Driver for behavioral tests. A production Codex Driver is intentionally not
-included; it belongs to issue #56.
+tools, resource limits or trace coverage. This repository ships `CodexDriver`,
+which executes one Codex Attempt through the native `codex exec --json` JSONL
+surface inside the admitted worktree, streaming bounded Activity Events before
+Codex exits and classifying terminal outcomes. `CodexDriver` supports only
+skill Harness Extensions, fails closed otherwise, and enforces the admitted
+token resource limit by terminating owned execution. A strict fake Driver
+remains beside the behavioral tests.
 
 An `AttemptOutcome.completed` moves a Run only to verification. Verification
 uses the admitted project policy and a frozen command or existing local/Kubernetes

--- a/tools/agent-orchestrator/RELEASE_NOTES.md
+++ b/tools/agent-orchestrator/RELEASE_NOTES.md
@@ -21,3 +21,16 @@ isolated recovery copy. Normal crash WAL files remain valid recovery input;
 corrupt, incomplete, and unsupported-version ledgers are refused without
 modification. `--reset-incompatible-state` remains strictly a legacy-state
 operation and cannot delete a current RunLedger.
+
+### CodexDriver executes real Attempts
+
+`aiwb daemon serve` now starts with the production `CodexDriver` instead of
+refusing to run. One admitted Run executes one Codex Attempt through
+`codex exec --json` inside the admitted AIWB worktree, streaming bounded
+Activity Events before Codex exits. The Driver validates the frozen Agent
+Harness Profile and fails closed on unsupported sandbox permissions, reasoning
+effort, capabilities, tools, paths, resource limits, native configuration,
+trace coverage, or non-skill Harness Extensions. An admitted `tokens` resource
+limit terminates owned execution with a typed `token budget exhausted` outcome.
+Quota, authentication, timeout, transport, and invalid-output failures are
+classified as typed terminal Attempt outcomes.

--- a/tools/agent-orchestrator/src/aiwb/__init__.py
+++ b/tools/agent-orchestrator/src/aiwb/__init__.py
@@ -15,6 +15,7 @@ from .browser import (
     BrowserDiagnosticResult,
     McpBrowserDiagnosticAdapter,
 )
+from .codex_driver import CodexDriver
 from .daemon import AgentDaemon, DaemonClient, DaemonError, RunStatus
 from .evidence import (
     EvidenceError,
@@ -136,6 +137,7 @@ __all__ = [
     "BrowserDiagnosticRequest",
     "BrowserDiagnosticResult",
     "CodeStructureEvidence",
+    "CodexDriver",
     "ExecutionManifest",
     "ExecutionSnapshot",
     "LeaseConflictError",

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 from typing import Optional, Sequence, Tuple
 
+from .codex_driver import CodexDriver
 from .daemon import AgentDaemon, DaemonClient, DaemonError
 from .github_pipeline import (
     GhApiGitHubSource,
@@ -679,9 +680,14 @@ def _run_daemon(options: argparse.Namespace) -> int:
             )
         if assessment.format == StateFormat.INCOMPATIBLE_CURRENT:
             raise DaemonError("incompatible_state", INCOMPATIBLE_CURRENT_STATE_MESSAGE)
-        raise ValueError(
-            "no production Agent Harness Driver is installed; issue #56 owns Codex"
+        agent_daemon = AgentDaemon(
+            options.state_dir,
+            CodexDriver(),
+            socket_path=_socket_path(options),
+            max_workers=options.max_workers,
         )
+        agent_daemon.serve_forever()
+        return 0
     if options.daemon_command == "status":
         socket_path = _socket_path(options)
         status = "ok" if DaemonClient(socket_path).ping() else "unavailable"

--- a/tools/agent-orchestrator/src/aiwb/codex_driver.py
+++ b/tools/agent-orchestrator/src/aiwb/codex_driver.py
@@ -1,0 +1,460 @@
+"""Production Agent Harness Driver for one bounded Codex Attempt.
+
+The Driver runs `codex exec --json` inside the admitted AIWB-owned worktree and
+streams the native JSONL surface into bounded ActivityEvents. It never resumes a
+provider Session, never falls back to another provider, and keeps large or raw
+provider payloads out of terminal summaries.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import threading
+from dataclasses import dataclass
+from typing import Callable, Mapping, Optional, Tuple
+
+from .agent_harness import (
+    ActivityEvent,
+    AgentHarnessProfile,
+    AttemptOutcome,
+    AttemptSpec,
+)
+
+_SUPPORTED_SANDBOX_MODES = frozenset(
+    ("read-only", "workspace-write", "danger-full-access")
+)
+_SUPPORTED_EFFORTS = frozenset(("minimal", "low", "medium", "high", "xhigh"))
+_SUPPORTED_CAPABILITIES = frozenset(("git",))
+_SUPPORTED_TOOLS = frozenset(("shell", "edit"))
+_SUPPORTED_ALLOWED_PATHS = (".",)
+_SUPPORTED_INPUT_ARTIFACT = "contract.yaml"
+_SUPPORTED_OUTPUT_SCHEMA = "attempt-outcome/v1"
+_SUPPORTED_RESOURCE_LIMIT_KEYS = frozenset(("tokens",))
+_SUPPORTED_NATIVE_CONFIGURATION = {"mode": "autonomous"}
+_SUPPORTED_EXTENSION_KINDS = ("skill",)
+_TRACE_CATEGORIES = frozenset(
+    ("activity", "extension", "lifecycle", "session", "terminal", "tool", "usage")
+)
+_EVENT_SUMMARY_LIMIT = 1024
+_OUTCOME_SUMMARY_LIMIT = 4096
+_STDERR_CAPTURE_LIMIT = 4096
+_TERMINATE_GRACE_SECONDS = 10.0
+
+
+@dataclass(frozen=True)
+class CodexDriver:
+    """Execute exactly one Codex Attempt through the native codex exec surface."""
+
+    codex_binary: str = "codex"
+
+    def validate(self, profile: AgentHarnessProfile) -> None:
+        """Fail closed before an external Codex Attempt is created."""
+        if profile.driver != "codex":
+            raise ValueError(f"unsupported Agent Harness Driver: {profile.driver}")
+        if shutil.which(self.codex_binary) is None:
+            raise ValueError(f"Codex binary is unavailable: {self.codex_binary}")
+        if (
+            len(profile.permissions) != 1
+            or profile.permissions[0] not in _SUPPORTED_SANDBOX_MODES
+        ):
+            raise ValueError(
+                f"unsupported Codex sandbox permissions: {', '.join(profile.permissions)}"
+            )
+        if profile.effort not in _SUPPORTED_EFFORTS:
+            raise ValueError(f"unsupported Codex reasoning effort: {profile.effort}")
+        unsupported = sorted(set(profile.capability_ceiling) - _SUPPORTED_CAPABILITIES)
+        if unsupported:
+            raise ValueError(f"unsupported Codex capability: {', '.join(unsupported)}")
+        unsupported = sorted(set(profile.tools) - _SUPPORTED_TOOLS)
+        if unsupported:
+            raise ValueError(f"unsupported Codex tool: {', '.join(unsupported)}")
+        if tuple(profile.allowed_paths) != _SUPPORTED_ALLOWED_PATHS:
+            raise ValueError(
+                "Codex supports the workspace root as the only allowed path"
+            )
+        if profile.input_artifact != _SUPPORTED_INPUT_ARTIFACT:
+            raise ValueError(
+                f"unsupported Codex input artifact: {profile.input_artifact}"
+            )
+        if profile.output_schema != _SUPPORTED_OUTPUT_SCHEMA:
+            raise ValueError(
+                f"unsupported Codex output schema: {profile.output_schema}"
+            )
+        unsupported = sorted(
+            set(profile.resource_limits) - _SUPPORTED_RESOURCE_LIMIT_KEYS
+        )
+        if unsupported:
+            raise ValueError(
+                f"unsupported Codex resource limit: {', '.join(unsupported)}"
+            )
+        tokens = profile.resource_limits.get("tokens")
+        if tokens is not None and (not isinstance(tokens, int) or tokens <= 0):
+            raise ValueError("Codex token resource limit must be a positive integer")
+        if dict(profile.native_configuration) != _SUPPORTED_NATIVE_CONFIGURATION:
+            raise ValueError(
+                "unsupported Codex native configuration: "
+                f"{dict(profile.native_configuration)}"
+            )
+        for extension in profile.extensions:
+            kind = extension.split(":", 1)[0]
+            if kind not in _SUPPORTED_EXTENSION_KINDS:
+                raise ValueError(f"unsupported Codex Harness Extension: {extension}")
+        if profile.extensions and not profile.resolved_extensions:
+            raise ValueError(
+                "Harness Extensions were not resolved before external execution"
+            )
+        unsupported = sorted(set(profile.trace_coverage) - _TRACE_CATEGORIES)
+        if unsupported:
+            raise ValueError(
+                f"unsupported Codex trace coverage: {', '.join(unsupported)}"
+            )
+
+    def execute(
+        self,
+        attempt_spec: AttemptSpec,
+        event_sink: Callable[[ActivityEvent], None],
+    ) -> AttemptOutcome:
+        """Run exactly one Codex Attempt without fallback or resume semantics."""
+        self.validate(attempt_spec.profile)
+        profile = attempt_spec.profile
+        binary = shutil.which(self.codex_binary)
+        if binary is None:
+            return AttemptOutcome.failed(
+                "Codex Attempt failed: Codex binary unavailable"
+            )
+        argv = (
+            binary,
+            "exec",
+            "--json",
+            "--ignore-user-config",
+            "--ignore-rules",
+            "--sandbox",
+            profile.permissions[0],
+            "-m",
+            profile.model,
+            "-c",
+            f'model_reasoning_effort="{profile.effort}"',
+            "-C",
+            str(attempt_spec.worktree),
+            attempt_spec.instructions,
+        )
+        event_sink(
+            ActivityEvent(kind="lifecycle", summary="Codex Attempt started")
+        )
+        for extension in profile.extensions:
+            event_sink(
+                ActivityEvent(
+                    kind="extension",
+                    summary=_bounded(f"Harness Extension resolved: {extension}"),
+                )
+            )
+        try:
+            process = subprocess.Popen(
+                argv,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
+            )
+        except OSError as error:
+            return AttemptOutcome.failed(
+                f"Codex Attempt failed: {type(error).__name__}: {error}"
+            )
+        stderr_tail: list = []
+        drain = threading.Thread(
+            target=_drain_stderr,
+            args=(process, stderr_tail),
+            name="aiwb-codex-stderr",
+            daemon=True,
+        )
+        drain.start()
+        stream = _CodexAttemptStream()
+        token_limit = profile.resource_limits.get("tokens")
+        token_budget_exceeded = False
+        assert process.stdout is not None
+        for line in process.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                stream.mark_invalid_output()
+                event_sink(
+                    ActivityEvent(
+                        kind="error",
+                        summary="Codex emitted invalid output",
+                        session_id=stream.session_id,
+                    )
+                )
+                continue
+            if isinstance(payload, Mapping):
+                for event in stream.events_for(payload):
+                    event_sink(event)
+            if (
+                isinstance(token_limit, int)
+                and stream.usage_tokens > token_limit
+            ):
+                token_budget_exceeded = True
+                process.terminate()
+                break
+        try:
+            returncode = process.wait(timeout=_TERMINATE_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            returncode = process.wait()
+        drain.join(timeout=_TERMINATE_GRACE_SECONDS)
+        if token_budget_exceeded:
+            event_sink(
+                ActivityEvent(
+                    kind="terminal",
+                    summary="Codex Attempt failed: token budget exhausted",
+                    session_id=stream.session_id,
+                )
+            )
+            return AttemptOutcome.failed(
+                "Codex Attempt failed: token budget exhausted",
+                session_id=stream.session_id,
+            )
+        if stream.invalid_output:
+            summary = "Codex Attempt failed: invalid output"
+        elif stream.failure_message or returncode != 0:
+            summary = _classify_failure(
+                stream.failure_message, "".join(stderr_tail), returncode
+            )
+        else:
+            event_sink(
+                ActivityEvent(
+                    kind="terminal",
+                    summary="Codex Attempt completed",
+                    session_id=stream.session_id,
+                )
+            )
+            message = stream.last_agent_message or "Codex Attempt completed"
+            return AttemptOutcome.completed(
+                _bounded(message, _OUTCOME_SUMMARY_LIMIT),
+                session_id=stream.session_id,
+            )
+        event_sink(
+            ActivityEvent(
+                kind="terminal",
+                summary=_bounded(summary),
+                session_id=stream.session_id,
+            )
+        )
+        return AttemptOutcome.failed(summary, session_id=stream.session_id)
+
+
+def _bounded(text: str, limit: int = _EVENT_SUMMARY_LIMIT) -> str:
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _drain_stderr(process: subprocess.Popen, tail: list) -> None:
+    captured = 0
+    assert process.stderr is not None
+    for line in process.stderr:
+        if captured >= _STDERR_CAPTURE_LIMIT:
+            continue
+        tail.append(line)
+        captured += len(line)
+
+
+def _usage_tokens(usage: Mapping) -> int:
+    total = 0
+    for key in ("input_tokens", "cached_input_tokens", "output_tokens"):
+        value = usage.get(key)
+        if isinstance(value, int) and value > 0:
+            total += value
+    return total
+
+
+def _classify_failure(failure_message: str, stderr_tail: str, returncode: int) -> str:
+    detail = failure_message or stderr_tail.strip()
+    lowered = detail.lower()
+    if any(
+        marker in lowered
+        for marker in ("usage limit", "rate limit", "insufficient_quota", "quota")
+    ):
+        return f"Codex Attempt failed: quota exhausted{_excerpt(detail)}"
+    if any(
+        marker in lowered
+        for marker in ("401", "unauthorized", "not logged in", "authentication")
+    ):
+        return f"Codex Attempt failed: authentication required{_excerpt(detail)}"
+    if "timed out" in lowered or "timeout" in lowered:
+        return f"Codex Attempt failed: timeout{_excerpt(detail)}"
+    if any(
+        marker in lowered
+        for marker in ("connection", "transport", "dns", "econn", "socket")
+    ):
+        return f"Codex Attempt failed: transport error{_excerpt(detail)}"
+    if detail:
+        return f"Codex Attempt failed{_excerpt(detail)}"
+    return f"Codex Attempt failed: exit status {returncode}"
+
+
+def _excerpt(detail: str) -> str:
+    excerpt = " ".join(detail.split())[:200]
+    return f": {excerpt}" if excerpt else ""
+
+
+class _CodexAttemptStream:
+    """Track one streamed Codex Attempt's terminal-relevant state."""
+
+    def __init__(self) -> None:
+        self.session_id = ""
+        self.last_agent_message = ""
+        self.failure_message = ""
+        self.usage_tokens = 0
+        self.invalid_output = False
+
+    def mark_invalid_output(self) -> None:
+        self.invalid_output = True
+
+    def events_for(self, payload: Mapping) -> Tuple[ActivityEvent, ...]:
+        event_type = payload.get("type")
+        if event_type == "thread.started":
+            self.session_id = str(payload.get("thread_id", ""))[:128]
+            return (
+                ActivityEvent(
+                    kind="session",
+                    summary="Codex Thread started",
+                    session_id=self.session_id,
+                ),
+            )
+        if event_type == "turn.started":
+            return (
+                ActivityEvent(
+                    kind="lifecycle",
+                    summary="Codex Turn started",
+                    session_id=self.session_id,
+                ),
+            )
+        if event_type == "turn.completed":
+            usage = payload.get("usage")
+            events = [
+                ActivityEvent(
+                    kind="lifecycle",
+                    summary="Codex Turn completed",
+                    session_id=self.session_id,
+                )
+            ]
+            if isinstance(usage, Mapping):
+                tokens = _usage_tokens(usage)
+                if tokens:
+                    self.usage_tokens = max(self.usage_tokens, tokens)
+                    events.append(
+                        ActivityEvent(
+                            kind="usage",
+                            summary=f"Codex usage: {tokens} tokens",
+                            session_id=self.session_id,
+                            usage_tokens=tokens,
+                        )
+                    )
+            return tuple(events)
+        if event_type == "turn.failed":
+            error = payload.get("error")
+            if isinstance(error, Mapping):
+                message = str(error.get("message", ""))
+            else:
+                message = str(error or "")
+            self.failure_message = message
+            return (
+                ActivityEvent(
+                    kind="error",
+                    summary=_bounded(f"Codex Turn failed: {message}"),
+                    session_id=self.session_id,
+                ),
+            )
+        if event_type == "error":
+            message = str(payload.get("message", ""))
+            if not self.failure_message:
+                self.failure_message = message
+            return (
+                ActivityEvent(
+                    kind="error",
+                    summary=_bounded(f"Codex error: {message}"),
+                    session_id=self.session_id,
+                ),
+            )
+        if event_type == "item.completed":
+            item = payload.get("item")
+            if isinstance(item, Mapping):
+                return self._item_events(item)
+        return ()
+
+    def _item_events(self, item: Mapping) -> Tuple[ActivityEvent, ...]:
+        item_type = item.get("type")
+        if item_type == "command_execution":
+            command = str(item.get("command", ""))
+            return (
+                ActivityEvent(
+                    kind="tool",
+                    summary=_bounded(f"Codex shell: {command}"),
+                    session_id=self.session_id,
+                ),
+            )
+        if item_type == "file_change":
+            changes = item.get("changes")
+            paths = []
+            if isinstance(changes, (list, tuple)):
+                paths = [
+                    str(change.get("path", ""))
+                    for change in changes
+                    if isinstance(change, Mapping)
+                ]
+            summary = (
+                f"Codex file change: {', '.join(paths)}"
+                if paths
+                else "Codex file change"
+            )
+            return (
+                ActivityEvent(
+                    kind="edit",
+                    summary=_bounded(summary),
+                    session_id=self.session_id,
+                ),
+            )
+        if item_type == "agent_message":
+            text = str(item.get("text", ""))
+            self.last_agent_message = text
+            return (
+                ActivityEvent(
+                    kind="activity",
+                    summary=_bounded(f"Codex message: {text}"),
+                    session_id=self.session_id,
+                ),
+            )
+        if item_type == "reasoning":
+            text = str(item.get("text", ""))
+            return (
+                ActivityEvent(
+                    kind="activity",
+                    summary=_bounded(f"Codex reasoning: {text}"),
+                    session_id=self.session_id,
+                ),
+            )
+        if item_type in ("web_search", "mcp_tool_call"):
+            label = "Codex web search" if item_type == "web_search" else "Codex MCP tool"
+            return (
+                ActivityEvent(
+                    kind="tool",
+                    summary=label,
+                    session_id=self.session_id,
+                ),
+            )
+        if item_type == "error":
+            message = str(item.get("message", ""))
+            return (
+                ActivityEvent(
+                    kind="error",
+                    summary=_bounded(f"Codex item error: {message}"),
+                    session_id=self.session_id,
+                ),
+            )
+        return ()

--- a/tools/agent-orchestrator/tests/test_codex_driver.py
+++ b/tools/agent-orchestrator/tests/test_codex_driver.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+TOOL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOL_ROOT / "src"))
+
+from aiwb import (  # noqa: E402
+    ActivityEvent,
+    Admission,
+    AdmissionRequest,
+    AgentHarnessProfile,
+    AttemptOutcome,
+    AttemptSpec,
+    CodexDriver,
+    GoalRunner,
+    SQLiteRunLedger,
+)
+from aiwb.runner import approve_execution  # noqa: E402
+
+
+_FAKE_CODEX_SCRIPT = """#!/usr/bin/env python3
+import json
+import os
+import sys
+import time
+
+scenario = os.environ.get("AIWB_FAKE_CODEX_SCENARIO", "success")
+
+
+def emit(payload):
+    sys.stdout.write(json.dumps(payload) + "\\n")
+    sys.stdout.flush()
+
+
+emit({"type": "thread.started", "thread_id": "thread-fake-1"})
+if scenario == "invalid_output":
+    sys.stdout.write("this is not json\\n")
+    sys.stdout.flush()
+    sys.exit(1)
+emit({"type": "turn.started"})
+if scenario == "quota":
+    message = "You've hit your usage limit."
+    emit({"type": "error", "message": message})
+    emit({"type": "turn.failed", "error": {"message": message}})
+    sys.exit(1)
+if scenario == "budget":
+    emit({"type": "turn.completed", "usage": {"input_tokens": 500, "output_tokens": 600}})
+    time.sleep(30)
+    sys.exit(0)
+emit({"type": "item.completed", "item": {"id": "item_0", "type": "command_execution",
+      "command": "echo greeting", "aggregated_output": "greeting\\n", "exit_code": 0}})
+if scenario == "stream":
+    time.sleep(0.6)
+emit({"type": "item.completed", "item": {"id": "item_1", "type": "file_change",
+      "changes": [{"path": "greeting.txt", "kind": "add"}]}})
+emit({"type": "item.completed", "item": {"id": "item_2", "type": "agent_message",
+      "text": "Implemented the greeting."}})
+emit({"type": "turn.completed", "usage": {"input_tokens": 120, "output_tokens": 30}})
+sys.exit(0)
+"""
+
+
+def _fake_codex(root: Path) -> Path:
+    path = root / "fake-codex"
+    path.write_text(_FAKE_CODEX_SCRIPT, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def _profile(**overrides: object) -> AgentHarnessProfile:
+    values = {
+        "driver": "codex",
+        "model": "gpt-test",
+        "effort": "high",
+        "permissions": ("workspace-write",),
+        "capability_ceiling": ("git",),
+        "extensions": (),
+        "allowed_paths": (".",),
+        "tools": ("shell",),
+        "input_artifact": "contract.yaml",
+        "output_schema": "attempt-outcome/v1",
+        "timeout_seconds": 60,
+        "max_attempts": 1,
+        "resource_limits": {"tokens": 1000},
+        "native_configuration": {"mode": "autonomous"},
+        "trace_coverage": ("activity",),
+    }
+    values.update(overrides)
+    return AgentHarnessProfile(**values)
+
+
+def _spec(root: Path, profile: AgentHarnessProfile) -> AttemptSpec:
+    worktree = root / "worktree"
+    worktree.mkdir(exist_ok=True)
+    return AttemptSpec(
+        run_id="run-1",
+        attempt_id="attempt-1",
+        worktree=worktree,
+        instructions="Implement the agreed greeting behavior.",
+        profile=profile,
+    )
+
+
+def _execute(driver: CodexDriver, root: Path, profile: AgentHarnessProfile):
+    events = []
+    outcome = driver.execute(_spec(root, profile), events.append)
+    return outcome, events
+
+
+def test_validate_rejects_unsupported_surfaces() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        driver = CodexDriver(str(_fake_codex(Path(directory))))
+        driver.validate(_profile())
+        unsupported = [
+            {"driver": "claude-code"},
+            {"permissions": ("network",)},
+            {"permissions": ("workspace-write", "read-only")},
+            {"effort": "extreme"},
+            {"capability_ceiling": ("git", "kubernetes")},
+            {"tools": ("shell", "browser")},
+            {"allowed_paths": (".", "/tmp")},
+            {"input_artifact": "other.yaml"},
+            {"output_schema": "attempt-outcome/v0"},
+            {"resource_limits": {"cpu": 2}},
+            {"resource_limits": {"tokens": 0}},
+            {"native_configuration": {"mode": "interactive"}},
+            {"extensions": ("mcp:search@1",)},
+            {"extensions": ("skill:focused@1",)},
+            {"trace_coverage": ("chain-of-thought",)},
+        ]
+        for override in unsupported:
+            with pytest.raises(ValueError):
+                driver.validate(_profile(**override))
+        missing = CodexDriver("aiwb-binary-that-does-not-exist")
+        with pytest.raises(ValueError):
+            missing.validate(_profile())
+
+
+def test_completed_attempt_streams_events_before_codex_exits() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        driver = CodexDriver(str(_fake_codex(root)))
+        events = []
+        first_event_at = None
+        started = time.monotonic()
+
+        def sink(event: ActivityEvent) -> None:
+            nonlocal first_event_at
+            if first_event_at is None:
+                first_event_at = time.monotonic()
+            events.append(event)
+
+        original = os.environ.get("AIWB_FAKE_CODEX_SCENARIO")
+        os.environ["AIWB_FAKE_CODEX_SCENARIO"] = "stream"
+        try:
+            outcome = driver.execute(_spec(root, _profile()), sink)
+        finally:
+            if original is None:
+                del os.environ["AIWB_FAKE_CODEX_SCENARIO"]
+            else:
+                os.environ["AIWB_FAKE_CODEX_SCENARIO"] = original
+
+        returned_at = time.monotonic()
+        assert outcome.status == "completed"
+        assert outcome.session_id == "thread-fake-1"
+        assert outcome.summary == "Implemented the greeting."
+        assert first_event_at is not None
+        assert returned_at - first_event_at >= 0.5
+        kinds = [event.kind for event in events]
+        assert "session" in kinds
+        assert "lifecycle" in kinds
+        assert "tool" in kinds
+        assert "edit" in kinds
+        assert "activity" in kinds
+        assert "usage" in kinds
+        assert kinds[-1] == "terminal"
+        usage = next(event for event in events if event.kind == "usage")
+        assert usage.usage_tokens == 150
+        assert all(event.session_id == "thread-fake-1" for event in events[1:])
+
+
+def test_quota_failure_is_classified_as_a_typed_outcome() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        driver = CodexDriver(str(_fake_codex(root)))
+        original = os.environ.get("AIWB_FAKE_CODEX_SCENARIO")
+        os.environ["AIWB_FAKE_CODEX_SCENARIO"] = "quota"
+        try:
+            outcome, events = _execute(driver, root, _profile())
+        finally:
+            if original is None:
+                del os.environ["AIWB_FAKE_CODEX_SCENARIO"]
+            else:
+                os.environ["AIWB_FAKE_CODEX_SCENARIO"] = original
+        assert outcome.status == "failed"
+        assert outcome.summary.startswith("Codex Attempt failed: quota exhausted")
+        assert outcome.session_id == "thread-fake-1"
+        assert events[-1].kind == "terminal"
+
+
+def test_invalid_output_is_classified_as_a_typed_outcome() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        driver = CodexDriver(str(_fake_codex(root)))
+        original = os.environ.get("AIWB_FAKE_CODEX_SCENARIO")
+        os.environ["AIWB_FAKE_CODEX_SCENARIO"] = "invalid_output"
+        try:
+            outcome, events = _execute(driver, root, _profile())
+        finally:
+            if original is None:
+                del os.environ["AIWB_FAKE_CODEX_SCENARIO"]
+            else:
+                os.environ["AIWB_FAKE_CODEX_SCENARIO"] = original
+        assert outcome.status == "failed"
+        assert outcome.summary == "Codex Attempt failed: invalid output"
+
+
+def test_token_budget_terminates_owned_execution() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        driver = CodexDriver(str(_fake_codex(root)))
+        original = os.environ.get("AIWB_FAKE_CODEX_SCENARIO")
+        os.environ["AIWB_FAKE_CODEX_SCENARIO"] = "budget"
+        started = time.monotonic()
+        try:
+            outcome, _events = _execute(driver, root, _profile())
+        finally:
+            if original is None:
+                del os.environ["AIWB_FAKE_CODEX_SCENARIO"]
+            else:
+                os.environ["AIWB_FAKE_CODEX_SCENARIO"] = original
+        assert time.monotonic() - started < 20
+        assert outcome.status == "failed"
+        assert outcome.summary == "Codex Attempt failed: token budget exhausted"
+
+
+def test_codex_driver_attempt_flows_through_admission_and_goal_runner() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = root / "repository"
+        repository.mkdir()
+        for command in (
+            ("git", "init", "-b", "main"),
+            ("git", "config", "user.name", "AI Workbench Test"),
+            ("git", "config", "user.email", "aiwb@example.test"),
+        ):
+            subprocess.run(command, cwd=repository, check=True, capture_output=True)
+        (repository / "README.md").write_text("fixture\n", encoding="utf-8")
+        skill = repository / ".codex" / "skills" / "focused" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text(
+            "---\nname: focused\ndescription: Focus this test attempt.\nversion: 1\n---\n\n# Focused\n",
+            encoding="utf-8",
+        )
+        subprocess.run(("git", "add", "."), cwd=repository, check=True)
+        subprocess.run(("git", "commit", "-m", "fixture"), cwd=repository, check=True)
+        contract = root / "contract.yaml"
+        contract.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": 5,
+                    "goal": {
+                        "id": "greeting",
+                        "title": "Add greeting",
+                        "requirement": "Add the agreed greeting behavior.",
+                        "acceptance": [{"id": "AC-1", "statement": "Tests pass."}],
+                    },
+                    "approval": {
+                        "artifact_path": str(root / "execution-approval.json"),
+                    },
+                    "instructions": "Implement the agreed greeting behavior.",
+                    "agent_harness": {
+                        "driver": "codex",
+                        "model": "gpt-test",
+                        "effort": "high",
+                        "permissions": ["workspace-write"],
+                        "capability_ceiling": ["git"],
+                        "extensions": ["skill:focused@1"],
+                        "allowed_paths": ["."],
+                        "tools": ["shell"],
+                        "input_artifact": "contract.yaml",
+                        "output_schema": "attempt-outcome/v1",
+                        "timeout_seconds": 60,
+                        "max_attempts": 1,
+                        "resource_limits": {"tokens": 1000},
+                        "native_configuration": {"mode": "autonomous"},
+                        "trace_coverage": [
+                            "activity",
+                            "extension",
+                            "lifecycle",
+                            "session",
+                            "terminal",
+                            "tool",
+                            "usage",
+                        ],
+                    },
+                    "project": {"repo": str(repository), "base_ref": "main"},
+                    "verification": {
+                        "command": [sys.executable, "-c", "raise SystemExit(0)"],
+                        "timeout_seconds": 30,
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        approve_execution(
+            contract,
+            approved_by="owner",
+            artifact_path=root / "execution-approval.json",
+            approved_at=datetime(2026, 8, 26, tzinfo=timezone.utc),
+        )
+        ledger = SQLiteRunLedger(root / "state" / "run-ledger.db")
+        admitted = Admission(
+            ledger,
+            engine_version="test-engine",
+            transition_policy_version="strict-v2",
+        ).admit(AdmissionRequest(contract))
+        driver = CodexDriver(str(_fake_codex(root)))
+
+        report = GoalRunner(root / "state", driver, ledger=ledger).run_snapshot(
+            ledger.execution_snapshot(admitted.snapshot_id),
+            run_id=admitted.run_id,
+        )
+
+        assert report.status == "candidate"
+        assert len(report.attempts) == 1
+        assert report.attempts[0].outcome == "completed"
+        assert report.attempts[0].session_id == "thread-fake-1"
+        kinds = {event.kind for event in report.activity}
+        assert {"session", "lifecycle", "tool", "edit", "activity", "usage", "terminal", "extension"} <= kinds
+        assert len(report.evidence) == 1


### PR DESCRIPTION
Closes #56

## Summary

- Add the production `CodexDriver` (`aiwb/codex_driver.py`) implementing the single-Attempt `AgentHarnessDriver` seam: `codex exec --json` runs inside the admitted AIWB worktree and streams the native JSONL surface into bounded Activity Events before Codex exits.
- `validate()` fails closed on unsupported sandbox permissions, reasoning effort, capabilities, tools, allowed paths, resource limits, native configuration, trace coverage, non-skill Harness Extensions, and missing binary.
- Terminal outcomes are typed: quota, authentication, timeout, transport, and invalid output are classified; the admitted `tokens` resource limit terminates owned execution with `token budget exhausted`.
- No provider fallback or Session resume; `subprocess.run(... PIPE ...)` is never used — stdout streams line by line with a bounded stderr drain thread.
- `aiwb daemon serve` now starts with `CodexDriver` instead of refusing (replaces the `cli.py` placeholder).

## Verification

- Full suite: 195 passed (189 existing + 6 new behavior tests in `tests/test_codex_driver.py`).
- Behavior tests cover the fail-closed validate matrix, streamed activity before Codex exits, typed quota/invalid-output outcomes, token-budget termination, and a full Admission → GoalRunner → Candidate flow with a fake codex binary.
- Manual smoke: `aiwb daemon serve` + `daemon status` ok.

## Notes

- Live end-to-end Codex Attempt verification is currently blocked by the account usage limit (resets Sep 7); the quota error event shape used by classification was captured from a real `codex exec --json` run.
- Codex 0.151.0 still reads `~/.codex/agents/*.toml` role files even with `--ignore-user-config`; tracked as ambient-config leakage for a follow-up issue.