### PR TITLE
Align intake skill readiness vocabulary with GoalIntake

### DIFF
--- a/.codex/skills/intake-aiwb-goal/SKILL.md
+++ b/.codex/skills/intake-aiwb-goal/SKILL.md
@@ -29,11 +29,11 @@ readiness blockers, or approval digest generation in this Skill.
 
 - `blocked`: report every blocker and the exact `next_action`; do not fill in
   acceptance, permissions, provider, resources, Harness, or environment
-  decisions yourself.
-- `ready_for_approval`: show the execution envelope and ask for one explicit
-  human Contract approval.
-- `ready_to_submit`: show the execution envelope and ask for explicit
-  submission. Do not submit merely because intake is ready.
+  decisions yourself. When `approval_required` is true, ask for one explicit
+  human Contract approval before anything else.
+- `ready`: show the execution envelope and, when `submission_required` is
+  true, ask for explicit submission. Do not submit merely because intake is
+  ready.
 
 Keep the provider and model fixed. Never suggest production access, automatic
 fallback, permission expansion, test weakening, or a replacement Run.

--- a/tools/agent-orchestrator/skills/intake-aiwb-goal/SKILL.md
+++ b/tools/agent-orchestrator/skills/intake-aiwb-goal/SKILL.md
@@ -29,11 +29,11 @@ readiness blockers, or approval digest generation in this Skill.
 
 - `blocked`: report every blocker and the exact `next_action`; do not fill in
   acceptance, permissions, provider, resources, Harness, or environment
-  decisions yourself.
-- `ready_for_approval`: show the execution envelope and ask for one explicit
-  human Contract approval.
-- `ready_to_submit`: show the execution envelope and ask for explicit
-  submission. Do not submit merely because intake is ready.
+  decisions yourself. When `approval_required` is true, ask for one explicit
+  human Contract approval before anything else.
+- `ready`: show the execution envelope and, when `submission_required` is
+  true, ask for explicit submission. Do not submit merely because intake is
+  ready.
 
 Keep the provider and model fixed. Never suggest production access, automatic
 fallback, permission expansion, test weakening, or a replacement Run.


### PR DESCRIPTION
## Summary

The `intake-aiwb-goal` Skill's Interpret section referenced `ready_for_approval` and `ready_to_submit`, but `GoalIntake` only ever reports `readiness` as `ready` or `blocked`; approval and submission state is expressed by the `approval_required` / `submission_required` booleans. This aligns the Skill vocabulary with the actual `GoalIntakeResult` fields, in both the bundled source and the `.codex/skills` mirror (kept in sync per `test_project_local_skill_mirrors_match_the_bundled_sources`).

## Verification

- `tests/test_skill_catalog.py` and `tests/test_skill_cli.py`: 29 passed.
