### PR TITLE
Resolve Harness Profiles, Models, and Extensions during guided setup (#80)

### DIFF
--- a/.codex/skills/setup-ai-workbench/SKILL.md
+++ b/.codex/skills/setup-ai-workbench/SKILL.md
@@ -123,6 +123,32 @@ that probe confirms the selected Harness can load the Extension; if the probe
 is unavailable or rejects it, Setup fails before writing. Do not treat
 descriptor metadata or an executable bit alone as proof of availability.
 
+## Resolve the Agent Harness Profile
+
+Setup resolves one exact Agent Harness Profile against the live Harness model
+catalog without starting an Attempt. Name the exact Model; effort defaults to
+the catalog's default reasoning level and may be pinned explicitly:
+
+```bash
+aiwb setup --repo /path/to/repository --agent-target codex \
+  --harness-model gpt-5.5
+```
+
+The read-only output shows the resolved Profile, the exact reasoning effort,
+sandbox permission (`--harness-permission`), token resource limit
+(`--harness-tokens`), named Extensions (`--harness-extension skill:name@version`),
+Trace Coverage (`--harness-trace-coverage`), the catalog source with its
+observation time and digest, any exposed internal-role Models, and the
+`profile_digest` locking all of it. Unsupported Models, efforts, or Extensions
+fail closed; hidden internal identifiers are never selectable as the primary
+Model. Any `--harness-*` flag requires `--harness-model`.
+
+After the owner confirms the preview, an explicit `--apply` persists the
+resolved Profile to the repository-local `.ai-workbench/agent-harness.yaml`.
+Apply is idempotent for an unchanged resolved Profile; any Model, effort,
+permission, Extension, or catalog drift requires a new explicit setup. Setup
+never edits user-global Agent configuration.
+
 ## Optional packs
 
 Offer packs only after inspection and only by explicit user choice. `matt` is

--- a/tools/agent-orchestrator/RELEASE_NOTES.md
+++ b/tools/agent-orchestrator/RELEASE_NOTES.md
@@ -34,3 +34,19 @@ trace coverage, or non-skill Harness Extensions. An admitted `tokens` resource
 limit terminates owned execution with a typed `token budget exhausted` outcome.
 Quota, authentication, timeout, transport, and invalid-output failures are
 classified as typed terminal Attempt outcomes.
+
+### Guided setup resolves the exact Agent Harness Profile
+
+`aiwb setup` can now resolve one exact Agent Harness Profile against the live
+Codex model catalog (`codex debug models`) without starting an Attempt. Name
+the exact Model with `--harness-model`; reasoning effort defaults to the
+catalog default and can be pinned with `--harness-effort`. The read-only
+preview displays the resolved Profile, sandbox permission, token resource
+limit, named Extensions with locked digests, Trace Coverage, catalog source and
+digest, exposed internal-role Models, and one `profile_digest`. Unsupported
+Models, efforts, or Extensions fail closed; hidden internal identifiers are
+never selectable as the primary Model. An explicit `--apply` persists the
+resolved Profile to the repository-local `.ai-workbench/agent-harness.yaml`;
+apply is idempotent for an unchanged resolved Profile, and any Model, effort,
+permission, Extension, or catalog drift requires a new explicit setup.
+`CodexDriver` now accepts the catalog's `max` and `ultra` reasoning efforts.

--- a/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
+++ b/tools/agent-orchestrator/skills/setup-ai-workbench/SKILL.md
@@ -123,6 +123,32 @@ that probe confirms the selected Harness can load the Extension; if the probe
 is unavailable or rejects it, Setup fails before writing. Do not treat
 descriptor metadata or an executable bit alone as proof of availability.
 
+## Resolve the Agent Harness Profile
+
+Setup resolves one exact Agent Harness Profile against the live Harness model
+catalog without starting an Attempt. Name the exact Model; effort defaults to
+the catalog's default reasoning level and may be pinned explicitly:
+
+```bash
+aiwb setup --repo /path/to/repository --agent-target codex \
+  --harness-model gpt-5.5
+```
+
+The read-only output shows the resolved Profile, the exact reasoning effort,
+sandbox permission (`--harness-permission`), token resource limit
+(`--harness-tokens`), named Extensions (`--harness-extension skill:name@version`),
+Trace Coverage (`--harness-trace-coverage`), the catalog source with its
+observation time and digest, any exposed internal-role Models, and the
+`profile_digest` locking all of it. Unsupported Models, efforts, or Extensions
+fail closed; hidden internal identifiers are never selectable as the primary
+Model. Any `--harness-*` flag requires `--harness-model`.
+
+After the owner confirms the preview, an explicit `--apply` persists the
+resolved Profile to the repository-local `.ai-workbench/agent-harness.yaml`.
+Apply is idempotent for an unchanged resolved Profile; any Model, effort,
+permission, Extension, or catalog drift requires a new explicit setup. Setup
+never edits user-global Agent configuration.
+
 ## Optional packs
 
 Offer packs only after inspection and only by explicit user choice. `matt` is

--- a/tools/agent-orchestrator/src/aiwb/__init__.py
+++ b/tools/agent-orchestrator/src/aiwb/__init__.py
@@ -82,6 +82,12 @@ from .recipe_catalog import (
     RecipeRefreshPreview,
     RecipeResolution,
 )
+from .profile_setup import (
+    HarnessExtensionDigest,
+    HarnessModelCatalog,
+    HarnessProfileResolution,
+    HarnessProfileSelections,
+)
 from .setup import SetupApplyResult, SetupInspection, WorkbenchSetup
 from .skills import (
     SkillCatalog,
@@ -166,12 +172,16 @@ __all__ = [
     "HarnessApplyResult",
     "HarnessAssessment",
     "HarnessCandidate",
+    "HarnessExtensionDigest",
     "HarnessExtensionResolution",
     "HarnessPlan",
     "HarnessFileProjection",
+    "HarnessModelCatalog",
     "HarnessProbeCommand",
     "HarnessProbeEvidence",
     "HarnessProfile",
+    "HarnessProfileResolution",
+    "HarnessProfileSelections",
     "HarnessRequest",
     "HarnessSetup",
     "HarnessSetupRequest",

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -24,6 +24,7 @@ from .harness_setup import (
 )
 from .intake import GoalIntake
 from .kubernetes import KubernetesJanitor
+from .profile_setup import HarnessProfileSelections
 from .project import (
     ProjectConfigError,
     ProjectInitError,
@@ -101,6 +102,15 @@ def _build_parser() -> argparse.ArgumentParser:
     setup.add_argument("--install-pack", action="append", default=[])
     setup.add_argument("--pack-skill", action="append", default=[])
     setup.add_argument("--pack-profile", action="append", default=[])
+    setup.add_argument("--harness-model")
+    setup.add_argument("--harness-effort")
+    setup.add_argument(
+        "--harness-permission",
+        choices=("read-only", "workspace-write", "danger-full-access"),
+    )
+    setup.add_argument("--harness-tokens", type=int)
+    setup.add_argument("--harness-extension", action="append", default=[])
+    setup.add_argument("--harness-trace-coverage", action="append", default=[])
     setup.add_argument("--planning-mode", choices=("python-l0",))
     setup.add_argument("--approve-plan", action="store_true")
     setup.add_argument("--approved-by")
@@ -328,11 +338,41 @@ def _run_setup(options: argparse.Namespace) -> int:
 
     setup = HarnessSetup()
     targets = tuple(options.agent_target)
+    harness_flags = (
+        options.harness_effort,
+        options.harness_permission,
+        options.harness_tokens,
+        options.harness_extension,
+        options.harness_trace_coverage,
+    )
+    if any(harness_flags) and not options.harness_model:
+        raise ValueError("Harness Profile resolution requires --harness-model")
+    profile_selections = None
+    if options.harness_model:
+        profile_selections = HarnessProfileSelections(
+            model=options.harness_model,
+            effort=options.harness_effort or "",
+            permissions=(
+                (options.harness_permission,)
+                if options.harness_permission
+                else ("workspace-write",)
+            ),
+            extensions=tuple(options.harness_extension),
+            trace_coverage=(
+                tuple(options.harness_trace_coverage) or ("activity",)
+            ),
+            resource_limits=(
+                {"tokens": options.harness_tokens}
+                if options.harness_tokens
+                else {"tokens": 100000}
+            ),
+        )
     plan = setup.plan(
         HarnessSetupRequest(
             repository=options.repo,
             agent_targets=targets,
             planning_mode=options.planning_mode or "",
+            profile_selections=profile_selections,
         )
     )
     if options.planning_mode:
@@ -472,10 +512,14 @@ def _run_setup(options: argparse.Namespace) -> int:
                 ],
                 "installed_packs": result.installed_packs,
                 "next_actions": result.next_actions,
+                "harness_profile": (
+                    result.profile.to_dict() if result.profile is not None else None
+                ),
                 **state_fields,
             }
         )
     else:
+        profile_resolution = setup.resolve_profile(plan.request)
         result = plan.assessment
         _print_json(
             {
@@ -494,6 +538,11 @@ def _run_setup(options: argparse.Namespace) -> int:
                     resolution.to_dict()
                     for resolution in skill_resolutions
                 ],
+                "harness_profile": (
+                    profile_resolution.to_dict()
+                    if profile_resolution is not None
+                    else None
+                ),
                 **state_fields,
             }
         )

--- a/tools/agent-orchestrator/src/aiwb/codex_driver.py
+++ b/tools/agent-orchestrator/src/aiwb/codex_driver.py
@@ -25,7 +25,9 @@ from .agent_harness import (
 _SUPPORTED_SANDBOX_MODES = frozenset(
     ("read-only", "workspace-write", "danger-full-access")
 )
-_SUPPORTED_EFFORTS = frozenset(("minimal", "low", "medium", "high", "xhigh"))
+_SUPPORTED_EFFORTS = frozenset(
+    ("minimal", "low", "medium", "high", "xhigh", "max", "ultra")
+)
 _SUPPORTED_CAPABILITIES = frozenset(("git",))
 _SUPPORTED_TOOLS = frozenset(("shell", "edit"))
 _SUPPORTED_ALLOWED_PATHS = (".",)

--- a/tools/agent-orchestrator/src/aiwb/harness_setup.py
+++ b/tools/agent-orchestrator/src/aiwb/harness_setup.py
@@ -39,6 +39,13 @@ from .github_pipeline import (
     append_pipeline_observation,
 )
 from .project import DoctorReport, ProjectDoctor, ProjectInitializer
+from .profile_setup import (
+    HarnessProfileResolution,
+    HarnessProfileSelections,
+    harness_profile_document,
+    resolve_harness_profile,
+)
+from .codex_driver import CodexDriver
 from .recipe_catalog import RecipeCatalog
 from .skills import (
     AGENT_SKILL_ROOTS,
@@ -60,6 +67,7 @@ class HarnessSetupRequest:
     operation: str = "setup"
     output_path: Optional[Path] = None
     planning_mode: str = ""
+    profile_selections: Optional["HarnessProfileSelections"] = None
 
 
 @dataclass(frozen=True)
@@ -213,6 +221,7 @@ class HarnessCandidate:
     next_actions: Tuple[str, ...] = ()
     status: str = ""
     suggestions: int = 0
+    profile: Optional["HarnessProfileResolution"] = None
 
 
 @dataclass(frozen=True)
@@ -270,6 +279,7 @@ class HarnessSetup:
         extension_probe: Optional[
             Callable[[str, Mapping[str, object], Path, Path], None]
         ] = None,
+        codex_driver: Optional[CodexDriver] = None,
     ) -> None:
         self._catalog = catalog or SkillCatalog()
         self._pack_catalog = pack_catalog or SkillPackCatalog()
@@ -278,7 +288,21 @@ class HarnessSetup:
         self._recipe_catalog = recipe_catalog or RecipeCatalog()
         self._project_recipe_catalog = project_recipe_catalog
         self._extension_probe = extension_probe or _run_declared_harness_probe
+        self._codex_driver = codex_driver or CodexDriver()
         self._initializer = ProjectInitializer()
+
+    def resolve_profile(
+        self, request: HarnessSetupRequest
+    ) -> Optional[HarnessProfileResolution]:
+        """Resolve the selected Agent Harness Profile without writing anything."""
+        if request.profile_selections is None:
+            return None
+        return resolve_harness_profile(
+            Path(request.repository),
+            request.profile_selections,
+            request.agent_targets,
+            driver=self._codex_driver,
+        )
 
     def inspect(self, request: HarnessSetupRequest) -> HarnessAssessment:
         if request.operation not in {"setup", "initialize"}:
@@ -661,6 +685,10 @@ class HarnessSetup:
                 yaml.safe_dump(document, sort_keys=False),
                 encoding="utf-8",
             )
+        profile_resolution = self.resolve_profile(plan.request)
+        if profile_resolution is not None:
+            if _write_harness_profile(repository, profile_resolution):
+                changed = True
         return HarnessCandidate(
             state="candidate",
             workflow_path=str(workflow),
@@ -686,6 +714,7 @@ class HarnessSetup:
                     if pack_plan.setup_action
                 )
             ),
+            profile=profile_resolution,
         )
 
     def verify(self, request: HarnessVerifyRequest) -> HarnessVerification:
@@ -963,6 +992,20 @@ def _terminate_process_group(process_group: int) -> None:
         os.killpg(process_group, signal.SIGKILL)
     except (ProcessLookupError, PermissionError):
         pass
+
+
+def _write_harness_profile(
+    repository: Path, resolution: HarnessProfileResolution
+) -> bool:
+    path = repository / ".ai-workbench" / "agent-harness.yaml"
+    document = yaml.safe_dump(
+        harness_profile_document(resolution), sort_keys=False
+    )
+    if path.is_file() and path.read_text(encoding="utf-8") == document:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _write_bytes_atomically(path, document.encode("utf-8"))
+    return True
 
 
 def _workflow_document(path: Path) -> dict[str, object]:

--- a/tools/agent-orchestrator/src/aiwb/profile_setup.py
+++ b/tools/agent-orchestrator/src/aiwb/profile_setup.py
@@ -1,0 +1,396 @@
+"""Resolve one exact Agent Harness Profile during guided setup.
+
+Resolution is read-only: it discovers the selected Harness's model catalog
+without starting an Attempt, fails closed on unsupported Models, reasoning
+efforts, or Extensions, and locks the resolved Profile, Extension digests, and
+catalog evidence behind one digest so any drift requires a new explicit setup.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Mapping, Optional, Tuple
+
+import yaml
+
+from .agent_harness import AgentHarnessProfile
+from .codex_driver import CodexDriver
+from .skills import AGENT_SKILL_ROOTS
+
+_CODEX_DISCOVERY_TIMEOUT_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class HarnessProfileSelections:
+    """The owner's explicit Harness Profile selections for one setup."""
+
+    model: str
+    effort: str = ""
+    permissions: Tuple[str, ...] = ("workspace-write",)
+    capability_ceiling: Tuple[str, ...] = ("git",)
+    tools: Tuple[str, ...] = ("shell",)
+    allowed_paths: Tuple[str, ...] = (".",)
+    extensions: Tuple[str, ...] = ()
+    timeout_seconds: int = 1800
+    max_attempts: int = 1
+    resource_limits: Mapping[str, object] = field(
+        default_factory=lambda: {"tokens": 100000}
+    )
+    native_configuration: Mapping[str, object] = field(
+        default_factory=lambda: {"mode": "autonomous"}
+    )
+    trace_coverage: Tuple[str, ...] = ("activity",)
+    input_artifact: str = "contract.yaml"
+    output_schema: str = "attempt-outcome/v1"
+
+
+@dataclass(frozen=True)
+class HarnessModelDescriptor:
+    slug: str
+    default_effort: str
+    efforts: Tuple[str, ...]
+    visibility: str
+
+
+@dataclass(frozen=True)
+class HarnessModelCatalog:
+    binary: str
+    version: str
+    resolved_at: str
+    catalog_sha256: str
+    models: Tuple[HarnessModelDescriptor, ...]
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "binary": self.binary,
+            "version": self.version,
+            "resolved_at": self.resolved_at,
+            "catalog_sha256": self.catalog_sha256,
+            "models": [
+                {
+                    "slug": model.slug,
+                    "default_effort": model.default_effort,
+                    "efforts": list(model.efforts),
+                    "visibility": model.visibility,
+                }
+                for model in self.models
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class HarnessExtensionDigest:
+    identity: str
+    path: str
+    sha256: str
+    entrypoint_sha256: str = ""
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "identity": self.identity,
+            "path": self.path,
+            "sha256": self.sha256,
+            "entrypoint_sha256": self.entrypoint_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class HarnessProfileResolution:
+    profile: AgentHarnessProfile
+    catalog: HarnessModelCatalog
+    internal_role_models: Tuple[str, ...]
+    extensions: Tuple[HarnessExtensionDigest, ...]
+    profile_digest: str
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "profile": harness_profile_mapping(self.profile),
+            "profile_digest": self.profile_digest,
+            "catalog": self.catalog.to_dict(),
+            "internal_role_models": list(self.internal_role_models),
+            "extensions": [extension.to_dict() for extension in self.extensions],
+        }
+
+
+def harness_profile_mapping(profile: AgentHarnessProfile) -> Mapping[str, object]:
+    """The contract-ready agent_harness mapping for one resolved Profile."""
+    return {
+        "driver": profile.driver,
+        "model": profile.model,
+        "effort": profile.effort,
+        "permissions": list(profile.permissions),
+        "capability_ceiling": list(profile.capability_ceiling),
+        "extensions": list(profile.extensions),
+        "allowed_paths": list(profile.allowed_paths),
+        "tools": list(profile.tools),
+        "input_artifact": profile.input_artifact,
+        "output_schema": profile.output_schema,
+        "timeout_seconds": profile.timeout_seconds,
+        "max_attempts": profile.max_attempts,
+        "resource_limits": dict(profile.resource_limits),
+        "native_configuration": dict(profile.native_configuration),
+        "trace_coverage": list(profile.trace_coverage),
+    }
+
+
+def harness_profile_document(resolution: HarnessProfileResolution) -> Mapping[str, object]:
+    """The persisted .ai-workbench/agent-harness.yaml document.
+
+    Freshness evidence (resolved_at) is display-only and stays out of the
+    persisted document so an unchanged resolved Profile is idempotent.
+    """
+    catalog = resolution.catalog
+    return {
+        "schema_version": 1,
+        "profile_digest": resolution.profile_digest,
+        "agent_harness": harness_profile_mapping(resolution.profile),
+        "catalog": {
+            "binary": catalog.binary,
+            "version": catalog.version,
+            "catalog_sha256": catalog.catalog_sha256,
+        },
+        "extensions": [extension.to_dict() for extension in resolution.extensions],
+    }
+
+
+def resolve_harness_profile(
+    repository: Path,
+    selections: HarnessProfileSelections,
+    agent_targets: Tuple[str, ...],
+    *,
+    driver: Optional[CodexDriver] = None,
+    clock: Optional[Callable[[], datetime]] = None,
+) -> HarnessProfileResolution:
+    """Resolve one exact Agent Harness Profile without starting an Attempt."""
+    repository = Path(repository).expanduser().resolve()
+    if not selections.model.strip():
+        raise ValueError("Harness Profile resolution requires an explicit Model")
+    if tuple(agent_targets) != ("codex",):
+        raise ValueError(
+            "Harness Profile resolution requires exactly the codex Agent target"
+        )
+    driver = driver or CodexDriver()
+    catalog = _discover_model_catalog(driver.codex_binary, clock)
+    models = {model.slug: model for model in catalog.models}
+    descriptor = models.get(selections.model)
+    if descriptor is None:
+        raise ValueError(f"Model is not in the Codex catalog: {selections.model}")
+    if descriptor.visibility != "list":
+        raise ValueError(
+            "Model is an internal Harness identifier, not a selectable primary "
+            f"Model: {selections.model}"
+        )
+    effort = selections.effort or descriptor.default_effort
+    if effort not in descriptor.efforts:
+        raise ValueError(
+            f"Model {selections.model} does not support reasoning effort: {effort}"
+        )
+    extensions = tuple(
+        _resolve_extension(repository, identity)
+        for identity in selections.extensions
+    )
+    profile = AgentHarnessProfile(
+        driver="codex",
+        model=selections.model,
+        effort=effort,
+        permissions=tuple(selections.permissions),
+        capability_ceiling=tuple(selections.capability_ceiling),
+        extensions=tuple(selections.extensions),
+        allowed_paths=tuple(selections.allowed_paths),
+        tools=tuple(selections.tools),
+        input_artifact=selections.input_artifact,
+        output_schema=selections.output_schema,
+        timeout_seconds=selections.timeout_seconds,
+        max_attempts=selections.max_attempts,
+        resource_limits=dict(selections.resource_limits),
+        native_configuration=dict(selections.native_configuration),
+        trace_coverage=tuple(selections.trace_coverage),
+        resolved_extensions=tuple(
+            {
+                "identity": extension.identity,
+                "path": extension.path,
+                "sha256": extension.sha256,
+            }
+            for extension in extensions
+        ),
+    )
+    driver.validate(profile)
+    digest_material = {
+        "profile": harness_profile_mapping(profile),
+        "extensions": [extension.to_dict() for extension in extensions],
+        "catalog_sha256": catalog.catalog_sha256,
+        "driver_version": catalog.version,
+    }
+    profile_digest = hashlib.sha256(
+        _canonical_json(digest_material).encode("utf-8")
+    ).hexdigest()
+    return HarnessProfileResolution(
+        profile=profile,
+        catalog=catalog,
+        internal_role_models=tuple(
+            model.slug for model in catalog.models if model.visibility != "list"
+        ),
+        extensions=extensions,
+        profile_digest=profile_digest,
+    )
+
+
+def _discover_model_catalog(
+    binary: str,
+    clock: Optional[Callable[[], datetime]],
+) -> HarnessModelCatalog:
+    path = shutil.which(binary)
+    if path is None:
+        raise ValueError(f"Codex binary is unavailable: {binary}")
+    version = _run_codex_discovery(path, ("--version",)).strip()
+    raw = _run_codex_discovery(path, ("debug", "models"))
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"Codex model catalog is invalid: {error}") from error
+    entries = data.get("models") if isinstance(data, dict) else None
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("Codex model catalog is invalid: missing models")
+    models = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Codex model catalog entry is invalid")
+        slug = entry.get("slug")
+        levels = entry.get("supported_reasoning_levels")
+        efforts = (
+            tuple(
+                str(level.get("effort"))
+                for level in levels
+                if isinstance(level, dict) and level.get("effort")
+            )
+            if isinstance(levels, list)
+            else ()
+        )
+        if not isinstance(slug, str) or not slug or not efforts:
+            raise ValueError("Codex model catalog entry is invalid")
+        models.append(
+            HarnessModelDescriptor(
+                slug=slug,
+                default_effort=str(entry.get("default_reasoning_level", "")),
+                efforts=efforts,
+                visibility=str(entry.get("visibility", "")),
+            )
+        )
+    instant = (clock or (lambda: datetime.now(timezone.utc)))()
+    return HarnessModelCatalog(
+        binary=path,
+        version=version,
+        resolved_at=instant.astimezone(timezone.utc).isoformat(),
+        catalog_sha256=hashlib.sha256(raw.encode("utf-8")).hexdigest(),
+        models=tuple(models),
+    )
+
+
+def _run_codex_discovery(binary: str, arguments: Tuple[str, ...]) -> str:
+    try:
+        completed = subprocess.run(
+            (binary, *arguments),
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=_CODEX_DISCOVERY_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise ValueError(
+            f"Codex discovery command failed: {type(error).__name__}"
+        ) from error
+    if completed.returncode != 0:
+        raise ValueError(
+            f"Codex discovery command failed: exit status {completed.returncode}"
+        )
+    return completed.stdout
+
+
+def _resolve_extension(repository: Path, identity: str) -> HarnessExtensionDigest:
+    match = re.fullmatch(
+        r"(skill|mcp|plugin|hook|command):([A-Za-z0-9._-]+)@([A-Za-z0-9._-]+)",
+        identity,
+    )
+    if match is None:
+        raise ValueError(f"Harness extension is unsupported or unresolved: {identity}")
+    kind, name, version = match.groups()
+    if kind == "skill":
+        skill_root = AGENT_SKILL_ROOTS.get("codex")
+        candidates = (
+            f"{skill_root}/{name}/SKILL.md",
+            f".agents/skills/{name}/SKILL.md",
+            f"skills/{name}/SKILL.md",
+        )
+    else:
+        candidates = (f".ai-workbench/extensions/{kind}/{name}.yaml",)
+    for relative in candidates:
+        source = repository / relative
+        if not source.is_file():
+            continue
+        source_bytes = source.read_bytes()
+        try:
+            text = source_bytes.decode("utf-8")
+            if kind == "skill":
+                if not text.startswith("---\n"):
+                    raise ValueError("missing metadata")
+                end = text.find("\n---\n", 4)
+                if end == -1:
+                    raise ValueError("unterminated metadata")
+                metadata = yaml.safe_load(text[4:end])
+            else:
+                metadata = yaml.safe_load(text)
+        except (UnicodeDecodeError, ValueError, yaml.YAMLError) as error:
+            raise ValueError(
+                f"Harness extension metadata is invalid: {identity}: {error}"
+            ) from error
+        if not isinstance(metadata, Mapping):
+            raise ValueError(f"Harness extension metadata is invalid: {identity}")
+        if (
+            metadata.get("name") != name
+            or str(metadata.get("version", "")) != version
+            or (kind != "skill" and metadata.get("kind") != kind)
+        ):
+            raise ValueError(
+                f"Harness extension identity or version does not match: {identity}"
+            )
+        digest = HarnessExtensionDigest(
+            identity=identity,
+            path=relative,
+            sha256=hashlib.sha256(source_bytes).hexdigest(),
+        )
+        if kind != "skill":
+            configuration = metadata.get("configuration")
+            entrypoint = (
+                configuration.get("entrypoint")
+                if isinstance(configuration, Mapping)
+                else None
+            )
+            entrypoint_path = (
+                (repository / entrypoint).resolve()
+                if isinstance(entrypoint, str) and entrypoint
+                else None
+            )
+            if entrypoint_path is None or not entrypoint_path.is_file():
+                raise ValueError(
+                    f"Harness extension has no callable entrypoint: {identity}"
+                )
+            digest = replace(
+                digest,
+                entrypoint_sha256=hashlib.sha256(
+                    entrypoint_path.read_bytes()
+                ).hexdigest(),
+            )
+        return digest
+    raise ValueError(f"Harness extension is not installed: {identity}")
+
+
+def _canonical_json(value: Mapping[str, object]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))

--- a/tools/agent-orchestrator/src/aiwb/setup.py
+++ b/tools/agent-orchestrator/src/aiwb/setup.py
@@ -9,6 +9,7 @@ from .harness_setup import (
     HarnessSetup,
     HarnessSetupRequest,
 )
+from .profile_setup import HarnessProfileResolution, HarnessProfileSelections
 from .skills import (
     SkillCatalog,
     SkillCatalogSnapshot,
@@ -35,6 +36,7 @@ class SetupApplyResult:
     agent_targets: Tuple[str, ...]
     installed_packs: Tuple[str, ...] = ()
     next_actions: Tuple[str, ...] = ()
+    profile: Optional[HarnessProfileResolution] = None
 
 
 class WorkbenchSetup:
@@ -80,11 +82,13 @@ class WorkbenchSetup:
         install_skills: Tuple[str, ...] = (),
         pack_skills: Optional[Mapping[str, Sequence[str]]] = None,
         pack_profiles: Optional[Mapping[str, Sequence[str]]] = None,
+        profile_selections: Optional[HarnessProfileSelections] = None,
     ) -> SetupApplyResult:
         plan = self._setup.plan(
             HarnessSetupRequest(
                 repository=repository,
                 agent_targets=agent_targets,
+                profile_selections=profile_selections,
             )
         )
         candidate = self._setup.apply(
@@ -103,4 +107,5 @@ class WorkbenchSetup:
             agent_targets=candidate.agent_targets,
             installed_packs=candidate.installed_packs,
             next_actions=candidate.next_actions,
+            profile=candidate.profile,
         )

--- a/tools/agent-orchestrator/tests/test_codex_driver.py
+++ b/tools/agent-orchestrator/tests/test_codex_driver.py
@@ -122,6 +122,8 @@ def test_validate_rejects_unsupported_surfaces() -> None:
     with tempfile.TemporaryDirectory() as directory:
         driver = CodexDriver(str(_fake_codex(Path(directory))))
         driver.validate(_profile())
+        for effort in ("minimal", "low", "medium", "high", "xhigh", "max", "ultra"):
+            driver.validate(_profile(effort=effort))
         unsupported = [
             {"driver": "claude-code"},
             {"permissions": ("network",)},

--- a/tools/agent-orchestrator/tests/test_profile_setup.py
+++ b/tools/agent-orchestrator/tests/test_profile_setup.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+TOOL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOL_ROOT / "src"))
+
+from aiwb import (  # noqa: E402
+    CodexDriver,
+    HarnessApplyRequest,
+    HarnessProfileSelections,
+    HarnessSetup,
+    HarnessSetupRequest,
+)
+from aiwb.profile_setup import resolve_harness_profile  # noqa: E402
+
+
+_CATALOG = {
+    "models": [
+        {
+            "slug": "gpt-test",
+            "display_name": "GPT Test",
+            "default_reasoning_level": "medium",
+            "supported_reasoning_levels": [
+                {"effort": "low"},
+                {"effort": "medium"},
+                {"effort": "high"},
+                {"effort": "xhigh"},
+                {"effort": "max"},
+            ],
+            "visibility": "list",
+        },
+        {
+            "slug": "gpt-internal",
+            "display_name": "GPT Internal",
+            "default_reasoning_level": "medium",
+            "supported_reasoning_levels": [{"effort": "medium"}],
+            "visibility": "hide",
+        },
+    ]
+}
+
+_FAKE_CODEX_SCRIPT = """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+catalog = os.environ.get("AIWB_FAKE_CODEX_CATALOG")
+if sys.argv[1:] == ["--version"]:
+    print("codex-cli 0.151.0")
+elif sys.argv[1:] == ["debug", "models"]:
+    print(catalog)
+else:
+    sys.exit(2)
+"""
+
+_FIXED_CLOCK = lambda: datetime(2026, 9, 3, tzinfo=timezone.utc)  # noqa: E731
+
+
+def _fake_codex(root: Path, catalog: dict = None) -> Path:
+    path = root / "fake-codex"
+    path.write_text(_FAKE_CODEX_SCRIPT, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    os.environ["AIWB_FAKE_CODEX_CATALOG"] = json.dumps(catalog or _CATALOG)
+    return path
+
+
+def _driver(root: Path, catalog: dict = None) -> CodexDriver:
+    return CodexDriver(str(_fake_codex(root, catalog)))
+
+
+def _selections(**overrides: object) -> HarnessProfileSelections:
+    values = {"model": "gpt-test"}
+    values.update(overrides)
+    return HarnessProfileSelections(**values)
+
+
+def _resolve(root: Path, selections: HarnessProfileSelections, catalog: dict = None):
+    return resolve_harness_profile(
+        root,
+        selections,
+        ("codex",),
+        driver=_driver(root, catalog),
+        clock=_FIXED_CLOCK,
+    )
+
+
+def test_resolve_produces_an_exact_profile_with_stable_digest() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        resolution = _resolve(root, _selections())
+        assert resolution.profile.driver == "codex"
+        assert resolution.profile.model == "gpt-test"
+        assert resolution.profile.effort == "medium"
+        assert resolution.profile.permissions == ("workspace-write",)
+        assert resolution.internal_role_models == ("gpt-internal",)
+        assert resolution.catalog.version == "codex-cli 0.151.0"
+        assert resolution.profile_digest == _resolve(root, _selections()).profile_digest
+
+
+def test_resolve_honors_an_explicit_supported_effort() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        resolution = _resolve(root, _selections(effort="max"))
+        assert resolution.profile.effort == "max"
+
+
+def test_resolve_fails_closed_on_unsupported_selections() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        with pytest.raises(ValueError, match="explicit Model"):
+            _resolve(root, _selections(model=" "))
+        with pytest.raises(ValueError, match="not in the Codex catalog"):
+            _resolve(root, _selections(model="gpt-unknown"))
+        with pytest.raises(ValueError, match="internal Harness identifier"):
+            _resolve(root, _selections(model="gpt-internal"))
+        with pytest.raises(ValueError, match="does not support reasoning effort"):
+            _resolve(root, _selections(effort="ultra"))
+        with pytest.raises(ValueError, match="codex Agent target"):
+            resolve_harness_profile(
+                root, _selections(), ("claude-code",),
+                driver=_driver(root), clock=_FIXED_CLOCK,
+            )
+        with pytest.raises(ValueError, match="codex Agent target"):
+            resolve_harness_profile(
+                root, _selections(), (),
+                driver=_driver(root), clock=_FIXED_CLOCK,
+            )
+
+
+def test_resolve_locks_named_extension_digests_and_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        skill = root / ".codex" / "skills" / "focused" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text(
+            "---\nname: focused\ndescription: Focus this attempt.\nversion: 1\n---\n\n# Focused\n",
+            encoding="utf-8",
+        )
+        resolution = _resolve(root, _selections(extensions=("skill:focused@1",)))
+        assert len(resolution.extensions) == 1
+        extension = resolution.extensions[0]
+        assert extension.identity == "skill:focused@1"
+        assert extension.path == ".codex/skills/focused/SKILL.md"
+        assert len(extension.sha256) == 64
+        assert resolution.profile.resolved_extensions
+        with pytest.raises(ValueError, match="not installed"):
+            _resolve(root, _selections(extensions=("skill:missing@1",)))
+        with pytest.raises(ValueError, match="identity or version does not match"):
+            _resolve(root, _selections(extensions=("skill:focused@2",)))
+        mcp = root / ".ai-workbench" / "extensions" / "mcp"
+        mcp.mkdir(parents=True)
+        entrypoint = root / "tools" / "mcp-server.sh"
+        entrypoint.parent.mkdir()
+        entrypoint.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        (mcp / "search.yaml").write_text(
+            "kind: mcp\nname: search\nversion: 1\ndriver: codex\n"
+            "configuration:\n  entrypoint: tools/mcp-server.sh\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="unsupported Codex Harness Extension"):
+            _resolve(root, _selections(extensions=("mcp:search@1",)))
+
+
+def test_profile_digest_tracks_model_effort_catalog_and_extension_drift() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        base = _resolve(root, _selections()).profile_digest
+        assert _resolve(root, _selections(model="gpt-test", effort="high")).profile_digest != base
+        changed_catalog = json.loads(json.dumps(_CATALOG))
+        changed_catalog["models"][0]["display_name"] = "GPT Test Renamed"
+        assert _resolve(root, _selections(), catalog=changed_catalog).profile_digest != base
+        skill = root / ".codex" / "skills" / "focused" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text(
+            "---\nname: focused\ndescription: v1.\nversion: 1\n---\n\n# Focused\n",
+            encoding="utf-8",
+        )
+        with_skill = _resolve(root, _selections(extensions=("skill:focused@1",))).profile_digest
+        skill.write_text(
+            "---\nname: focused\ndescription: v1 updated.\nversion: 1\n---\n\n# Focused\n",
+            encoding="utf-8",
+        )
+        assert _resolve(root, _selections(extensions=("skill:focused@1",))).profile_digest != with_skill
+
+
+def test_apply_persists_the_resolved_profile_idempotently() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = root / "project"
+        repository.mkdir()
+        driver = _driver(root)
+        setup = HarnessSetup(codex_driver=driver)
+        request = HarnessSetupRequest(
+            repository=repository,
+            agent_targets=("codex",),
+            profile_selections=_selections(),
+        )
+        plan = setup.plan(request)
+        candidate = setup.apply(HarnessApplyRequest(plan=plan, confirmed=True))
+        profile_path = repository / ".ai-workbench" / "agent-harness.yaml"
+        assert candidate.profile is not None
+        assert profile_path.is_file()
+        document = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+        assert document["profile_digest"] == candidate.profile.profile_digest
+        assert document["agent_harness"]["model"] == "gpt-test"
+        assert document["agent_harness"]["effort"] == "medium"
+        first_contents = profile_path.read_text(encoding="utf-8")
+
+        second = setup.apply(HarnessApplyRequest(plan=setup.plan(request), confirmed=True))
+        assert second.changed is False
+        assert profile_path.read_text(encoding="utf-8") == first_contents
+
+        changed_request = HarnessSetupRequest(
+            repository=repository,
+            agent_targets=("codex",),
+            profile_selections=_selections(effort="high"),
+        )
+        third = setup.apply(
+            HarnessApplyRequest(plan=setup.plan(changed_request), confirmed=True)
+        )
+        assert third.changed is True
+        updated = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+        assert updated["agent_harness"]["effort"] == "high"
+        assert updated["profile_digest"] != document["profile_digest"]


### PR DESCRIPTION
Closes #80 (absorbs #84)

## Summary

- New `aiwb/profile_setup.py`: `resolve_harness_profile` resolves one exact `AgentHarnessProfile` against the live Codex model catalog (`codex debug models`) without starting an Attempt. The owner's exact `--harness-model` slug must exist with `visibility: list`; effort defaults to the catalog's `default_reasoning_level` or is pinned explicitly and must be in that model's supported levels. Hidden identifiers (`gpt-reserve`, `codex-auto-review`) are recorded as exposed internal-role Models and are never selectable as primary.
- Explicitly named Extensions (`skill:name@version`) are resolved from the working tree with locked sha256 digests (descriptor + entrypoint); missing, mismatched, or unsupported kinds fail closed. The resolved profile must pass `CodexDriver.validate`.
- One `profile_digest` locks profile fields + extension digests + catalog digest + driver version, so any Model/effort/permission/Extension/catalog drift shows up as a changed resolution requiring a new explicit setup.
- Wiring: `HarnessSetupRequest.profile_selections`, read-only `HarnessSetup.resolve_profile`, and `HarnessSetup.apply` persisting the contract-ready profile to `.ai-workbench/agent-harness.yaml` — idempotent for an unchanged resolved Profile (freshness evidence stays display-only, out of the persisted document).
- CLI: `aiwb setup --harness-model/--harness-effort/--harness-permission/--harness-tokens/--harness-extension/--harness-trace-coverage`; any `--harness-*` flag requires `--harness-model`. Inspect output shows the full resolution; `--apply` writes only project-local files, never user-global config.
- `CodexDriver` now accepts the catalog's `max`/`ultra` reasoning efforts so setup resolution and Run-time validation agree.
- Docs: `setup-ai-workbench` Skill (+ `.codex/skills` mirror) and RELEASE_NOTES.

## Verification

- Full suite: 201 passed (6 new behavior tests in `tests/test_profile_setup.py` + extended driver effort cases).
- Real-catalog smoke: `aiwb setup --repo <fixture> --agent-target codex --harness-model gpt-5.5` resolved effort `medium` from the live catalog with internal-role models reported; first `--apply` wrote `.ai-workbench/agent-harness.yaml`, second apply was a no-op.
