### PR TITLE
Prepare hash-stable overnight Run proposals (#86)

### DIFF
--- a/tools/agent-orchestrator/RELEASE_NOTES.md
+++ b/tools/agent-orchestrator/RELEASE_NOTES.md
@@ -50,3 +50,18 @@ resolved Profile to the repository-local `.ai-workbench/agent-harness.yaml`;
 apply is idempotent for an unchanged resolved Profile, and any Model, effort,
 permission, Extension, or catalog drift requires a new explicit setup.
 `CodexDriver` now accepts the catalog's `max` and `ultra` reasoning efforts.
+
+### Hash-stable overnight Run proposals
+
+`aiwb goal propose` prepares one read-only validated Run proposal from the
+setup-resolved Agent Harness Profile (`.ai-workbench/agent-harness.yaml`), one
+approved project policy command (`--command-name`), and the owner's
+natural-language goal, acceptance, and instructions. The proposal is written as
+a schema-v5 Contract under `.ai-workbench/proposals/`, validated through the
+same Admission preview, and displayed with its `execution_digest` and the exact
+approve and submit commands. Submitting with the digest as the idempotency key
+makes duplicate submission of one approved proposal create no duplicate Run,
+and any changed Profile, Model, Extension, command, permission, limit, or base
+commit invalidates the approval as before. No separate proposal store is
+created: the Contract file, the external approval artifact, and the RunLedger
+remain canonical.

--- a/tools/agent-orchestrator/src/aiwb/__init__.py
+++ b/tools/agent-orchestrator/src/aiwb/__init__.py
@@ -88,6 +88,7 @@ from .profile_setup import (
     HarnessProfileResolution,
     HarnessProfileSelections,
 )
+from .proposal import RunProposal, prepare_proposal
 from .setup import SetupApplyResult, SetupInspection, WorkbenchSetup
 from .skills import (
     SkillCatalog,
@@ -212,6 +213,7 @@ __all__ = [
     "RecipeFinding",
     "RecipeRefreshPreview",
     "RecipeResolution",
+    "RunProposal",
     "RunReport",
     "RunLedger",
     "RunLease",

--- a/tools/agent-orchestrator/src/aiwb/cli.py
+++ b/tools/agent-orchestrator/src/aiwb/cli.py
@@ -24,6 +24,7 @@ from .harness_setup import (
 )
 from .intake import GoalIntake
 from .kubernetes import KubernetesJanitor
+from .proposal import prepare_proposal
 from .profile_setup import HarnessProfileSelections
 from .project import (
     ProjectConfigError,
@@ -224,6 +225,21 @@ def _build_parser() -> argparse.ArgumentParser:
     approve.add_argument("--workflow", type=Path)
     approve.add_argument("--approved-by", required=True)
     approve.add_argument("--approval-artifact", required=True, type=Path)
+
+    propose = goal_commands.add_parser("propose")
+    propose.add_argument("--repo", required=True, type=Path)
+    propose.add_argument("--goal-id", required=True)
+    propose.add_argument("--title", required=True)
+    propose.add_argument("--requirement", required=True)
+    propose.add_argument("--acceptance", action="append", default=[])
+    propose.add_argument("--instructions", required=True)
+    propose.add_argument("--command-name", required=True)
+    propose.add_argument("--approval-artifact", required=True, type=Path)
+    propose.add_argument("--output", type=Path)
+    propose.add_argument("--base-ref", default="HEAD")
+    propose.add_argument(
+        "--verification-timeout-seconds", type=int, default=900
+    )
 
     daemon = commands.add_parser("daemon")
     daemon_commands = daemon.add_subparsers(dest="daemon_command", required=True)
@@ -678,6 +694,33 @@ def _run_goal(options: argparse.Namespace) -> int:
             contract_path=options.contract,
         )
         _print_json(result.to_dict())
+        return 0
+    if options.goal_command == "propose":
+        proposal = prepare_proposal(
+            options.repo,
+            goal_id=options.goal_id,
+            title=options.title,
+            requirement=options.requirement,
+            acceptance=tuple(options.acceptance),
+            instructions=options.instructions,
+            command_name=options.command_name,
+            approval_artifact=options.approval_artifact,
+            output_path=options.output,
+            base_ref=options.base_ref,
+            verification_timeout_seconds=options.verification_timeout_seconds,
+        )
+        _print_json(
+            {
+                "proposal": proposal.to_dict(),
+                "next_actions": [
+                    f"aiwb goal approve --contract {proposal.contract_path} "
+                    f"--approved-by <owner> --approval-artifact "
+                    f"{proposal.approval_artifact}",
+                    f"aiwb goal submit --contract {proposal.contract_path} "
+                    f"--idempotency-key {proposal.execution_digest}",
+                ],
+            }
+        )
         return 0
     if options.goal_command == "run":
         client = DaemonClient(_socket_path(options))

--- a/tools/agent-orchestrator/src/aiwb/proposal.py
+++ b/tools/agent-orchestrator/src/aiwb/proposal.py
@@ -1,0 +1,190 @@
+"""Prepare one hash-stable overnight Run proposal.
+
+A proposal composes the setup-resolved Agent Harness Profile
+(`.ai-workbench/agent-harness.yaml`), one approved project policy command, and
+the owner's natural-language goal and instructions into a schema-v5 Contract,
+then validates it through the Admission-equivalent preview. Approval binding,
+stale invalidation, and idempotent enqueue reuse the existing Contract
+approval artifact and RunLedger idempotency keys; no separate proposal store is
+created.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional, Tuple
+
+import yaml
+
+from .project import ProjectPolicy
+from .runner import ExecutionEnvelope, preview_execution
+
+_AGENT_HARNESS_PATH = ".ai-workbench/agent-harness.yaml"
+
+
+@dataclass(frozen=True)
+class RunProposal:
+    contract_path: str
+    goal_id: str
+    approval_status: str
+    approval_artifact: str
+    execution_digest: str
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "contract_path": self.contract_path,
+            "goal_id": self.goal_id,
+            "approval_status": self.approval_status,
+            "approval_artifact": self.approval_artifact,
+            "execution_digest": self.execution_digest,
+        }
+
+
+def prepare_proposal(
+    repository: Path,
+    *,
+    goal_id: str,
+    title: str,
+    requirement: str,
+    acceptance: Tuple[str, ...],
+    instructions: str,
+    command_name: str,
+    approval_artifact: Path,
+    output_path: Optional[Path] = None,
+    base_ref: str = "HEAD",
+    verification_timeout_seconds: int = 900,
+) -> RunProposal:
+    """Prepare one read-only validated Run proposal Contract."""
+    repository = Path(repository).expanduser().resolve()
+    if not repository.is_dir():
+        raise ValueError(f"repository is not a directory: {repository}")
+    for name, value in (
+        ("goal_id", goal_id),
+        ("title", title),
+        ("requirement", requirement),
+        ("instructions", instructions),
+        ("command_name", command_name),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"proposal {name} must be a non-empty string")
+    acceptance_items = []
+    for entry in acceptance:
+        identifier, separator, statement = entry.partition(":")
+        if not separator or not identifier.strip() or not statement.strip():
+            raise ValueError(
+                "proposal acceptance entries must be '<id>: <statement>'"
+            )
+        acceptance_items.append(
+            {"id": identifier.strip(), "statement": statement.strip()}
+        )
+    if not acceptance_items:
+        raise ValueError("proposal requires at least one acceptance statement")
+    if verification_timeout_seconds <= 0:
+        raise ValueError("proposal verification timeout must be positive")
+
+    profile_document = _load_agent_harness_profile(repository)
+    policy_path = repository / ".ai-workbench" / "workflow.yaml"
+    policy = ProjectPolicy.load(policy_path)
+    command = _approved_command(policy_path, policy, repository, command_name)
+
+    approval_artifact = Path(approval_artifact).expanduser().resolve()
+    try:
+        approval_artifact.relative_to(repository)
+    except ValueError:
+        pass
+    else:
+        raise ValueError(
+            "proposal approval artifact must stay outside the target repository"
+        )
+    if output_path is None:
+        output_path = (
+            repository / ".ai-workbench" / "proposals" / f"{goal_id}.contract.yaml"
+        )
+    output_path = Path(output_path).expanduser().resolve()
+    if output_path.exists():
+        raise ValueError(f"proposal Contract already exists: {output_path}")
+
+    contract = {
+        "schema_version": 5,
+        "goal": {
+            "id": goal_id,
+            "title": title,
+            "requirement": requirement,
+            "acceptance": acceptance_items,
+        },
+        "approval": {"artifact_path": str(approval_artifact)},
+        "instructions": instructions,
+        "agent_harness": profile_document,
+        "project": {"repo": str(repository), "base_ref": base_ref},
+        "verification": {
+            "command": list(command),
+            "timeout_seconds": verification_timeout_seconds,
+        },
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        yaml.safe_dump(contract, sort_keys=False), encoding="utf-8"
+    )
+    envelope = preview_execution(output_path)
+    return _proposal(output_path, envelope)
+
+
+def _proposal(contract_path: Path, envelope: ExecutionEnvelope) -> RunProposal:
+    return RunProposal(
+        contract_path=str(contract_path),
+        goal_id=envelope.goal_id,
+        approval_status=envelope.approval_status,
+        approval_artifact=envelope.approval_artifact,
+        execution_digest=envelope.execution_digest,
+    )
+
+
+def _load_agent_harness_profile(repository: Path) -> Mapping[str, object]:
+    path = repository / _AGENT_HARNESS_PATH
+    try:
+        document = yaml.safe_load(path.read_bytes())
+    except (OSError, yaml.YAMLError) as error:
+        raise ValueError(
+            f"proposal requires a setup-resolved Agent Harness Profile at "
+            f"{_AGENT_HARNESS_PATH}: {error}"
+        ) from error
+    if not isinstance(document, dict) or document.get("schema_version") != 1:
+        raise ValueError(
+            f"Agent Harness Profile at {_AGENT_HARNESS_PATH} is invalid"
+        )
+    if not document.get("profile_digest"):
+        raise ValueError(
+            f"Agent Harness Profile at {_AGENT_HARNESS_PATH} has no digest"
+        )
+    profile = document.get("agent_harness")
+    if not isinstance(profile, dict) or not profile:
+        raise ValueError(
+            f"Agent Harness Profile at {_AGENT_HARNESS_PATH} has no agent_harness mapping"
+        )
+    return profile
+
+
+def _approved_command(
+    policy_path: Path,
+    policy: ProjectPolicy,
+    repository: Path,
+    command_name: str,
+) -> Tuple[str, ...]:
+    document = yaml.safe_load(policy_path.read_bytes())
+    commands = document.get("capabilities", {}).get("commands", {})
+    definition = commands.get(command_name)
+    if not isinstance(definition, dict):
+        raise ValueError(
+            f"proposal command is not a declared project capability: {command_name}"
+        )
+    argv = definition.get("argv")
+    if (
+        not isinstance(argv, list)
+        or not argv
+        or not all(isinstance(item, str) and item for item in argv)
+    ):
+        raise ValueError(f"proposal command has no argv: {command_name}")
+    command = tuple(argv)
+    policy.authorize(repository, command)
+    return command

--- a/tools/agent-orchestrator/tests/test_proposal.py
+++ b/tools/agent-orchestrator/tests/test_proposal.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+TOOL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOL_ROOT / "src"))
+
+from aiwb import (  # noqa: E402
+    Admission,
+    AdmissionRequest,
+    AdmissionError,
+    SQLiteRunLedger,
+    prepare_proposal,
+)
+from aiwb import cli as cli_module  # noqa: E402
+from aiwb.runner import approve_execution, preview_execution  # noqa: E402
+
+
+_PROFILE = {
+    "driver": "codex",
+    "model": "gpt-test",
+    "effort": "high",
+    "permissions": ["workspace-write"],
+    "capability_ceiling": ["git"],
+    "extensions": [],
+    "allowed_paths": ["."],
+    "tools": ["shell"],
+    "input_artifact": "contract.yaml",
+    "output_schema": "attempt-outcome/v1",
+    "timeout_seconds": 60,
+    "max_attempts": 1,
+    "resource_limits": {"tokens": 1000},
+    "native_configuration": {"mode": "autonomous"},
+    "trace_coverage": ["activity"],
+}
+
+_TEST_COMMAND = [sys.executable, "-c", "raise SystemExit(0)"]
+
+
+def _project(root: Path) -> Path:
+    repository = root / "project"
+    repository.mkdir()
+    for command in (
+        ("git", "init", "-b", "main"),
+        ("git", "config", "user.name", "AI Workbench Test"),
+        ("git", "config", "user.email", "aiwb@example.test"),
+    ):
+        subprocess.run(command, cwd=repository, check=True, capture_output=True)
+    (repository / "README.md").write_text("fixture\n", encoding="utf-8")
+    subprocess.run(("git", "add", "."), cwd=repository, check=True)
+    subprocess.run(("git", "commit", "-m", "fixture"), cwd=repository, check=True)
+    ai_dir = repository / ".ai-workbench"
+    ai_dir.mkdir()
+    (ai_dir / "workflow.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "status": "approved",
+                "project": {"root": ".", "trusted": True},
+                "capabilities": {
+                    "commands": {
+                        "test": {"argv": _TEST_COMMAND, "approved": True},
+                        "lint": {
+                            "argv": [sys.executable, "-c", "pass"],
+                            "approved": True,
+                        },
+                    },
+                    "skills": {},
+                },
+                "harness": {"profiles": {}},
+                "images": {"profiles": {}},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return repository
+
+
+def _agent_harness(repository: Path, **profile_overrides: object) -> None:
+    profile = dict(_PROFILE)
+    profile.update(profile_overrides)
+    (repository / ".ai-workbench" / "agent-harness.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "profile_digest": "0" * 64,
+                "agent_harness": profile,
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _prepare(root: Path, repository: Path, **overrides: object):
+    arguments = {
+        "goal_id": "overnight-1",
+        "title": "Overnight task",
+        "requirement": "Implement the agreed behavior.",
+        "acceptance": ("AC-1: Verification passes.",),
+        "instructions": "Implement the agreed behavior.",
+        "command_name": "test",
+        "approval_artifact": root / "approvals" / "overnight-1.json",
+    }
+    arguments.update(overrides)
+    return prepare_proposal(repository, **arguments)
+
+
+def test_proposal_is_hash_stable_and_validated_like_admission() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _project(root)
+        _agent_harness(repository)
+        proposal = _prepare(root, repository)
+        assert proposal.approval_status == "draft"
+        assert proposal.goal_id == "overnight-1"
+        contract = Path(proposal.contract_path)
+        assert contract.is_file()
+        assert contract.parent == repository.resolve() / ".ai-workbench" / "proposals"
+        envelope = preview_execution(contract)
+        assert envelope.execution_digest == proposal.execution_digest
+        again = _prepare(
+            root, repository, output_path=root / "elsewhere.contract.yaml"
+        )
+        assert again.execution_digest == proposal.execution_digest
+
+
+def test_proposal_fails_closed_on_missing_setup_profile_and_unapproved_command() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _project(root)
+        with pytest.raises(ValueError, match="agent-harness.yaml"):
+            _prepare(root, repository)
+        _agent_harness(repository)
+        with pytest.raises(ValueError, match="not a declared project capability"):
+            _prepare(root, repository, command_name="unknown")
+        with pytest.raises(ValueError, match="acceptance"):
+            _prepare(root, repository, acceptance=())
+        with pytest.raises(ValueError, match="acceptance"):
+            _prepare(root, repository, acceptance=("no separator",))
+        with pytest.raises(ValueError, match="instructions"):
+            _prepare(root, repository, instructions="  ")
+        with pytest.raises(ValueError, match="outside the target repository"):
+            _prepare(
+                root,
+                repository,
+                approval_artifact=repository / "inside.json",
+            )
+        _prepare(root, repository)
+        with pytest.raises(ValueError, match="already exists"):
+            _prepare(root, repository)
+
+
+def test_changed_inputs_produce_a_new_digest() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _project(root)
+        _agent_harness(repository)
+        base = _prepare(root, repository)
+        variants = (
+            {"instructions": "Implement the behavior differently."},
+            {"command_name": "lint"},
+        )
+        for index, override in enumerate(variants):
+            changed = _prepare(
+                root,
+                repository,
+                output_path=root / f"variant-{index}.contract.yaml",
+                approval_artifact=root / "approvals" / f"variant-{index}.json",
+                **override,
+            )
+            assert changed.execution_digest != base.execution_digest
+        _agent_harness(repository, model="gpt-other")
+        changed = _prepare(
+            root,
+            repository,
+            output_path=root / "variant-model.contract.yaml",
+            approval_artifact=root / "approvals" / "variant-model.json",
+        )
+        assert changed.execution_digest != base.execution_digest
+
+
+def test_duplicate_submission_of_one_approved_digest_creates_no_duplicate_run() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _project(root)
+        _agent_harness(repository)
+        proposal = _prepare(root, repository)
+        approve_execution(
+            Path(proposal.contract_path),
+            approved_by="owner",
+            artifact_path=Path(proposal.approval_artifact),
+            approved_at=datetime(2026, 9, 3, tzinfo=timezone.utc),
+        )
+        ledger = SQLiteRunLedger(root / "state" / "run-ledger.db")
+        admission = Admission(
+            ledger,
+            engine_version="test-engine",
+            transition_policy_version="strict-v2",
+        )
+        key = proposal.execution_digest
+        first = admission.admit(
+            AdmissionRequest(Path(proposal.contract_path), idempotency_key=key)
+        )
+        second = admission.admit(
+            AdmissionRequest(Path(proposal.contract_path), idempotency_key=key)
+        )
+        assert second.run_id == first.run_id
+        assert len(ledger.projection(first.run_id).attempts) == 0
+        assert [run.run_id for run in ledger.queued_runs()] == [first.run_id]
+
+        changed = _prepare(
+            root,
+            repository,
+            output_path=root / "changed.contract.yaml",
+            approval_artifact=root / "approvals" / "changed.json",
+            instructions="Implement something else.",
+        )
+        approve_execution(
+            Path(changed.contract_path),
+            approved_by="owner",
+            artifact_path=Path(changed.approval_artifact),
+            approved_at=datetime(2026, 9, 3, tzinfo=timezone.utc),
+        )
+        with pytest.raises(AdmissionError, match="idempotency key"):
+            admission.admit(
+                AdmissionRequest(Path(changed.contract_path), idempotency_key=key)
+            )
+
+
+def test_goal_propose_cli_displays_the_decision_package(capsys) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        repository = _project(root)
+        _agent_harness(repository)
+        exit_code = cli_module.main(
+            [
+                "goal", "propose",
+                "--repo", str(repository),
+                "--goal-id", "overnight-1",
+                "--title", "Overnight task",
+                "--requirement", "Implement the agreed behavior.",
+                "--acceptance", "AC-1: Verification passes.",
+                "--instructions", "Implement the agreed behavior.",
+                "--command-name", "test",
+                "--approval-artifact", str(root / "approvals" / "overnight-1.json"),
+            ]
+        )
+        assert exit_code == 0
+        output = json.loads(capsys.readouterr().out)
+        proposal = output["proposal"]
+        assert proposal["approval_status"] == "draft"
+        assert len(proposal["execution_digest"]) == 64
+        approve_action, submit_action = output["next_actions"]
+        assert proposal["contract_path"] in approve_action
+        assert proposal["approval_artifact"] in approve_action
+        assert f"--idempotency-key {proposal['execution_digest']}" in submit_action


### PR DESCRIPTION
Closes #86

## Summary

- New `aiwb/proposal.py`: `prepare_proposal` composes the setup-resolved Agent Harness Profile (#80's `.ai-workbench/agent-harness.yaml`), one approved project policy command (`--command-name`, enforced via `ProjectPolicy.authorize`), and the owner's natural-language goal/acceptance/instructions into a schema-v5 Contract under `.ai-workbench/proposals/`, then validates it through the same Admission preview (`preview_execution`) — read-only, hash-stable, no durable Run state.
- New CLI `aiwb goal propose` displays the complete decision package (contract path, approval status, `execution_digest`) plus the exact `goal approve` and `goal submit --idempotency-key <digest>` commands.
- Reused unchanged, per the issue's no-overlapping-authorities constraint: approval binding (`approve_execution`), stale invalidation (`_execution_digest` covers Profile/Model/Extensions/commands/permissions/limits/base_commit), and idempotent enqueue (`Admission.admit(idempotency_key=...)` — same key + same snapshot returns the existing Run; same key + changed content is rejected). No new stores; contract file, external approval artifact, and RunLedger stay canonical.

## Verification

- Full suite: 206 passed (5 new behavior tests in `tests/test_proposal.py`, including the previously untested Admission idempotency path: duplicate digest submission returns the same Run; same key with changed contract raises).
- Manual smoke: fixture repo with real `agent-harness.yaml` + approved policy — `goal propose` printed the digest and next actions; `goal approve` + `goal preflight` confirmed `approved` with an unchanged digest.
