### PR TITLE
Add single-issue trial, Kimi discovery checks and repository license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,9 @@ Organize entries by artifact type. Use `Domain:` metadata when useful; keep setu
 - Record structural or governance changes in `decisions/` before introducing a new top-level directory.
 - Keep notes concise and practical: explain when to use an entry, how it is set up, and its current evaluation status.
 - Keep executable integrations self-contained under `tools/`; document reusable usage patterns under `workflows/`.
+
+## License
+
+AI Workbench's maintained environment tooling, first-party Skills and documentation are licensed under [Apache License 2.0](LICENSE), except material carrying its own license or third-party notices.
+
+The [engineering-principles instruction pack](skills/engineering-principles/LICENSE) remains MIT-licensed. Third-party material and linked or externally installed tools/Skills retain their original licenses and attribution; the repository license does not relicense them.

--- a/skills/README.md
+++ b/skills/README.md
@@ -10,6 +10,8 @@ Only profile-selected first-party files are managed by the environment tool. Ups
 
 ## Index
 
+- [单 Issue 轻量试用](../workflows/single-issue-trial.md) — 装好后做一个小 Issue，复用项目流程并区分试用与验收。
+
 - [reflect-bug](reflect-bug/SKILL.md) — 分析漏测原因并记录有证据、有适用边界的项目经验教训.
 - [review-lessons](review-lessons/SKILL.md) — 核对项目经验的有效性，合并重复项并保留历史证据与来源.
 - [handoff-to-dev](handoff-to-dev/SKILL.md) — 核对工作快照与目标环境，把当前任务安全交接到指定开发机.

--- a/tools/environment/README.md
+++ b/tools/environment/README.md
@@ -170,3 +170,13 @@ Brewfile 只登记实测确认归 Homebrew 所有的 formula。**`ripgrep` 不�
 该 Profile 保留 Homebrew cask Codex、桌面内置 Codex、nvm Node 和 Kimi 自带工具，未登记首装/升级渠道。
 `apply` 只管理选定的七个第一方 Skills；`uv` 为可选缺失项。Codex CLI 与桌面原生发现均纳入 `check`。
 Kimi 的 `doctor` 和 ACP Skill 命令发现单独实测，尚未纳入自动 `check`，不能由该命令的成功推断 Kimi 行为验收。
+
+### Kimi native discovery (#94)
+
+The home-mac check invokes `python3 kimi_skills_discovery.py kimi`. It uses [Kimi ACP](https://moonshotai.github.io/kimi-code/en/reference/kimi-acp) initialize/session/new and [available_commands_update](https://agentclientprotocol.com/protocol/v1/slash-commands), preserving the real HOME in an empty temporary cwd. No authenticate, model prompt or tool request is sent. Kimi can write its own session/log metadata; this is a local diagnostic, not a filesystem-only read or Skill execution.
+
+Required names come from all Skill components in the profile (currently seven), including when --only filters installation checks; discovery remains profile-wide. Missing names, configuration/protocol errors, incomplete output and timeout fail without scan fallback or automatic retry. Diagnostics identify the failure stage without raw client errors. The protocol deadline defaults to 45 seconds; AIWB_DISCOVERY_TIMEOUT accepts (0,120] seconds, plus up to about 2 seconds for cleanup. Output is bounded to 4 MiB and the owned process group is reaped.
+
+ACP advertises commands, not source file paths or on-disk uniqueness. Policy: retain and explicitly report third-party skill:README as an allowed extra command, outside first-party Skill acceptance. Directory hygiene still treats the root README as a non-Skill file. These are different observations; do not delete or rewrite upstream content to make the counts equal.
+
+The regression command includes isolated ACP and profile checks. Run `python3 tools/environment/tests/kimi_discovery.py` separately for focused diagnosis; failures retain the first fixture requests/results rather than retrying to green. See [validation evidence](kimi-discovery-validation.md).

--- a/tools/environment/env.py
+++ b/tools/environment/env.py
@@ -1053,6 +1053,23 @@ def check_skill_duplicates(ctx, report):
             continue
         if found is None:
             continue
+        if spec.get("require_profile_skills"):
+            expected = {c["name"] for c in ctx.profile["components"] if c["type"] == "skill"}
+            missing = sorted(expected - set(found))
+            if missing:
+                errors += 1
+                report.line("  %s：缺少 Profile Skill ✗ %s" % (client, ", ".join(missing)))
+        if spec.get("discovery_format") == "commands":
+            report.line("  %s：原生命令发现 %d 项（ACP 不提供源文件路径，不能证明文件归属或实际执行）"
+                        % (client, len(found)))
+            if "README" in found:
+                report.line("    额外原生命令 skill:README：保留上游索引，不计入第一方 Skill 验收，不修改文件")
+            # Names are the only native identity; do not fabricate source paths.
+            for name, commands in sorted(found.items()):
+                if len(commands) != 1:
+                    errors += 1
+                    report.line("    重复命令 ✗ %s" % name)
+            continue
         dups = 0
         for name in sorted(found):
             paths = found[name]

--- a/tools/environment/home-mac-validation.md
+++ b/tools/environment/home-mac-validation.md
@@ -55,7 +55,7 @@ Kimi 命令发现按 [ACP session setup](https://agentclientprotocol.com/protoco
 
 ## 后续与恢复
 
-Kimi 的原生命令发现本次单独实测，尚未并入自动 check；其 `skill:README` 与目录卫生检查的口径差异已记为 [#94](https://github.com/blackfaced/ai-workbench/issues/94)。不修改上游 README 来掩盖该差异。
+本报告验证当时，Kimi 的原生命令发现为单独实测，未并入自动 check；其 `skill:README` 与目录卫生检查的口径差异已记为 [#94](https://github.com/blackfaced/ai-workbench/issues/94)。不修改上游 README 来掩盖该差异。
 
 新机首装、软件升级、真实模型任务、远端交接仍未验证。工作 Mac 与 Linux 的既有报告不由本轮本机检查替代。
 
@@ -65,3 +65,7 @@ Kimi 的原生命令发现本次单独实测，尚未并入自动 check；其 `s
 sh tools/environment/bootstrap.sh --profile home-mac --check
 python3 tools/environment/env.py restore --backup 20260911T174609Z --dry-run
 ```
+
+## Follow-up #94 (2026-09-13)
+
+The historical manual result above is unchanged. Native Kimi discovery is now wired into check, with an explicit extra-command policy for skill:README; see [new validation](kimi-discovery-validation.md). Its local 0.39.0 evidence does not retroactively establish automated acceptance on this home Mac 0.41.0.

--- a/tools/environment/kimi-discovery-validation.md
+++ b/tools/environment/kimi-discovery-validation.md
@@ -1,0 +1,13 @@
+# Kimi discovery validation
+
+- Domain: ops
+- Date: 2026-09-13
+- Scope: Issue #94; local Kimi 0.39.0 native ACP and isolated fixtures.
+
+Before implementation the positive fixture failed because kimi_skills_discovery.py did not exist. The same path passed after implementation. Cases cover notifications before/after the session response (including one pipe write), empty lists, missing profile Skills, initialize/session errors, configuration exit, malformed JSON/schema, duplicate commands, wrong session, missing notifications, partial-line/silent timeout, direct child/descendant cleanup and README preservation. Failed tests retain first-request/result artifacts without automatic retries.
+
+Native command: `python3 tools/environment/kimi_skills_discovery.py /Users/bytedance/.kimi-code/bin/kimi`, exit 0 on Kimi 0.39.0. All seven first-party commands were observed. The adapter sends initialize/session/new only, with an empty cwd and no forwarded MCP servers or model prompt. No client installation, configuration or login state was changed; client-owned session/log metadata may be written.
+
+The home Mac 0.41.0 manual result remains in the [original report](home-mac-validation.md). Run `sh tools/environment/bootstrap.sh --profile home-mac --check` there to verify this new automated entry. This local protocol test does not establish home-machine full-profile acceptance or Skill execution.
+
+Full environment regression: 85 checks passed, including the five Kimi test methods and their protocol subcases. Markdown local references resolve; diff whitespace checks pass. These are local validation results, not remote CI.

--- a/tools/environment/kimi_skills_discovery.py
+++ b/tools/environment/kimi_skills_discovery.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Bounded, prompt-free Kimi ACP discovery. Output name<TAB>acp:skill:name.
+
+ACP exposes command names, not source paths. Only initialize and session/new
+are sent; never authenticate, prompt, execute a tool or modify installed Skills.
+Kimi may maintain its own session/log metadata during this local diagnostic.
+"""
+import json
+import math
+import os
+import re
+import select
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+from skills_discovery import reap
+
+
+def messages(proc, deadline):
+    buffered = b""
+    total = 0
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("ACP discovery timed out")
+        ready, _, _ = select.select([proc.stdout], [], [], min(remaining, 0.5))
+        if not ready:
+            continue
+        chunk = os.read(proc.stdout.fileno(), 65536)
+        if not chunk:
+            raise ValueError("ACP closed before discovery completed (check Kimi configuration)")
+        total += len(chunk)
+        if total > 4 * 1024 * 1024:
+            raise ValueError("ACP discovery exceeded 4 MiB")
+        buffered += chunk
+        while b"\n" in buffered:
+            raw, buffered = buffered.split(b"\n", 1)
+            try:
+                msg = json.loads(raw)
+            except (ValueError, UnicodeError):
+                raise ValueError("ACP returned malformed JSON") from None
+            if not isinstance(msg, dict) or msg.get("jsonrpc") != "2.0":
+                raise ValueError("ACP returned an invalid envelope")
+            yield msg
+
+
+def send(proc, request_id, method, params):
+    proc.stdin.write((json.dumps({"jsonrpc":"2.0", "id":request_id,
+                                 "method":method, "params":params})+"\n").encode())
+    proc.stdin.flush()
+
+
+def discover(proc, cwd, deadline):
+    send(proc, 1, "initialize", {"protocolVersion":1, "clientCapabilities":{},
+                               "clientInfo":{"name":"aiwb-discovery", "version":"1"}})
+    initialized = False
+    session_id = None
+    updates = {}
+    for msg in messages(proc, deadline):
+        if "error" in msg:
+            # Remote errors may contain config or credential values: keep only the stage.
+            raise ValueError("ACP RPC error during %s" % ("session/new" if initialized else "initialize"))
+        if "method" in msg and "id" in msg:
+            raise ValueError("ACP requested client operations during read-only discovery")
+        if msg.get("id") == 1:
+            result = msg.get("result")
+            if initialized or not isinstance(result, dict) or result.get("protocolVersion") != 1:
+                raise ValueError("ACP initialize response is invalid")
+            initialized = True
+            send(proc, 2, "session/new", {"cwd":cwd, "mcpServers":[]})
+        elif msg.get("id") == 2:
+            result = msg.get("result")
+            if not initialized or not isinstance(result, dict) or not isinstance(result.get("sessionId"), str) or not result["sessionId"]:
+                raise ValueError("ACP session/new response is invalid")
+            session_id = result["sessionId"]
+        elif msg.get("method") == "session/update":
+            params = msg.get("params")
+            if not isinstance(params, dict) or not isinstance(params.get("update"), dict):
+                raise ValueError("ACP session/update is invalid")
+            update = params["update"]
+            if update.get("sessionUpdate") != "available_commands_update":
+                continue
+            sid, commands = params.get("sessionId"), update.get("availableCommands")
+            if not isinstance(sid, str) or not sid or not isinstance(commands, list):
+                raise ValueError("ACP command list is invalid")
+            names = []
+            for command in commands:
+                if (not isinstance(command, dict) or not isinstance(command.get("name"), str)
+                        or not command["name"] or not isinstance(command.get("description"), str)):
+                    raise ValueError("ACP command entry is invalid")
+                name = command["name"]
+                if name.startswith("skill:"):
+                    name = name[len("skill:"):]
+                    if not re.fullmatch(r"[A-Za-z0-9_-]+", name) or name in names:
+                        raise ValueError("ACP Skill command is invalid or duplicated")
+                    names.append(name)
+            updates[sid] = names
+        if session_id is not None and session_id in updates:
+            return sorted(updates[session_id])
+
+
+def main(argv):
+    if len(argv) > 1:
+        sys.stderr.write("usage: kimi_skills_discovery.py [kimi-binary]\n")
+        return 2
+    try:
+        timeout = float(os.environ.get("AIWB_DISCOVERY_TIMEOUT", "45"))
+        if not math.isfinite(timeout) or not 0 < timeout <= 120:
+            raise ValueError("timeout must be in (0, 120]")
+        binary = argv[0] if argv else "kimi"
+        # An empty cwd avoids loading arbitrary project integrations; HOME is preserved
+        # so native user-level discovery and configuration are actually checked.
+        with tempfile.TemporaryDirectory(prefix="aiwb-kimi-discovery-") as cwd:
+            proc = subprocess.Popen([binary, "acp"], cwd=cwd, stdin=subprocess.PIPE,
+                                    stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                                    start_new_session=True)
+            try:
+                names = discover(proc, cwd, time.monotonic() + timeout)
+            finally:
+                # Own process group only; include descendants even if the leader exited.
+                try:
+                    os.killpg(proc.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+                reap(proc)
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+        for name in names:
+            print("%s\tacp:skill:%s" % (name, name))
+        return 0
+    except TimeoutError:
+        sys.stderr.write("Kimi ACP discovery timed out; no trusted list\n")
+        return 4
+    except (OSError, ValueError) as exc:
+        # No raw server output, credential values, or implicit retries.
+        detail = str(exc) if isinstance(exc, ValueError) else type(exc).__name__
+        sys.stderr.write("Kimi discovery failed: %s\n" % detail)
+        return 5
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/environment/profiles/home-mac.json
+++ b/tools/environment/profiles/home-mac.json
@@ -17,6 +17,11 @@
     },
     "shared": {
       "skills_dir": "~/.agents/skills"
+    },
+    "kimi": {
+      "discovery_cmd": "python3 kimi_skills_discovery.py kimi",
+      "discovery_format": "commands",
+      "require_profile_skills": true
     }
   },
   "user_bin_dirs": [
@@ -26,7 +31,7 @@
   ],
   "skill_notes": [
     "Codex CLI 与桌面内置运行时分别验证原生 skills/list。共享目录中的第一方 Skill 安装验证不代表已通过模型行为验收。",
-    "Kimi Code 0.41.0 配置由 kimi doctor 验证；Skill 原生发现与实际执行单独记录在家用 Mac 验证报告。"
+    "Kimi ACP 仅 initialize/session/new，核对 Profile 全部第一方 Skill 命令；不发模型 prompt。skill:README 是允许保留的第三方额外命令，不计作第一方 Skill，不删除上游文件。"
   ],
   "components": [
     {

--- a/tools/environment/tests/kimi_discovery.py
+++ b/tools/environment/tests/kimi_discovery.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Isolated ACP fixture tests; no real HOME, configuration or model calls."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+
+ENV_DIR = Path(__file__).resolve().parents[1]
+ARTIFACTS = Path(tempfile.mkdtemp(prefix="aiwb-kimi-fixtures-"))
+
+SERVER = r'''#!/usr/bin/env python3
+import json, os, signal, subprocess, sys, time
+from pathlib import Path
+root = Path(__file__).parent
+mode = root.joinpath("mode").read_text()
+root.joinpath("pid").write_text(str(os.getpid()))
+if mode == "config":
+    sys.exit(2)
+if mode == "child":
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    root.joinpath("child-pid").write_text(str(child.pid))
+def emit(value):
+    print(json.dumps(value), flush=True)
+for raw in sys.stdin:
+    req = json.loads(raw)
+    with root.joinpath("requests").open("a") as f:
+        f.write(req["method"] + "\n")
+    assert req["method"] in ("initialize", "session/new")
+    if req["method"] == "initialize":
+        if mode == "init-error":
+            emit({"jsonrpc":"2.0", "id":1, "error":{"code":-32000,"message":"secret-error"}})
+        else:
+            emit({"jsonrpc":"2.0", "id":1, "result":{"protocolVersion":1}})
+        continue
+    assert req["params"]["mcpServers"] == []
+    assert Path(req["params"]["cwd"]).is_absolute()
+    if mode in ("silent", "child"):
+        time.sleep(30)
+        continue
+    if mode == "partial":
+        sys.stdout.write('{"jsonrpc":'); sys.stdout.flush(); time.sleep(30)
+        continue
+    if mode == "malformed":
+        print("not json", flush=True); continue
+    if mode == "new-error":
+        emit({"jsonrpc":"2.0", "id":2, "error":{"code":-32602,"message":"secret-error"}}); continue
+    result = {"jsonrpc":"2.0", "id":2, "result":{"sessionId":"fixture-session"}}
+    commands = [{"name":"skill:demo-skill", "description":"fixture"},
+                {"name":"skill:README", "description":"upstream index"}]
+    if mode == "empty": commands = []
+    if mode == "duplicate": commands += commands[:1]
+    if mode == "bad-shape": commands = {}
+    if mode == "bad-entry": commands = [{"name":"skill:demo-skill"}]
+    update = {"jsonrpc":"2.0", "method":"session/update", "params":{
+        "sessionId":"other" if mode == "wrong-session" else "fixture-session",
+        "update":{"sessionUpdate":"available_commands_update", "availableCommands":commands}}}
+    if mode == "before":
+        # Notification and response in a single pipe write must both survive buffering.
+        sys.stdout.write(json.dumps(update)+"\n"+json.dumps(result)+"\n");sys.stdout.flush()
+    else:
+        emit(result)
+        if mode not in ("no-list", "early-eof"): emit(update)
+    if mode == "early-eof": sys.exit(0)
+'''
+
+class KimiDiscoveryTest(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(dir=ARTIFACTS))
+        self.client = self.root / "kimi"
+        self.client.write_text(SERVER)
+        self.client.chmod(0o755)
+        self.env = dict(os.environ, HOME=str(self.root), AIWB_DISCOVERY_TIMEOUT="0.8")
+
+    def probe(self, mode):
+        (self.root / "mode").write_text(mode)
+        started = time.monotonic()
+        p = subprocess.run([sys.executable, str(ENV_DIR / "kimi_skills_discovery.py"),
+                            str(self.client)], env=self.env, capture_output=True, text=True, timeout=5)
+        (self.root / (mode + ".result.json")).write_text(json.dumps({"returncode": p.returncode, "stdout": p.stdout, "stderr": p.stderr}))
+        self.assertLess(time.monotonic()-started, 4)
+        # Exit status is not enough: ensure the actual client PID was reaped.
+        pid = self.root / "pid"
+        self.assertTrue(pid.exists(), p.stderr)
+        with self.assertRaises(ProcessLookupError): os.kill(int(pid.read_text()), 0)
+        requests = self.root / "requests"
+        if mode != "config": self.assertTrue(requests.exists(), p.stderr)
+        if requests.exists():
+            self.assertLessEqual(set(requests.read_text().splitlines()), {"initialize", "session/new"})
+        return p
+
+    def test_notifications_before_and_after_response(self):
+        for mode in ("before", "after"):
+            with self.subTest(mode=mode):
+                p = self.probe(mode)
+                self.assertEqual(p.returncode, 0, p.stderr)
+                self.assertIn("demo-skill\tacp:skill:demo-skill", p.stdout)
+                self.assertIn("README\tacp:skill:README", p.stdout)
+
+    def test_failures_are_not_partial_success_or_secret_output(self):
+        for mode in ("config", "init-error", "new-error", "malformed", "bad-shape", "bad-entry", "early-eof", "duplicate",
+                     "no-list", "wrong-session", "partial", "silent"):
+            with self.subTest(mode=mode):
+                p = self.probe(mode)
+                self.assertNotEqual(p.returncode, 0)
+                self.assertEqual(p.stdout, "")
+                self.assertNotIn("secret-error", p.stderr)
+                self.assertTrue(p.stderr.strip())
+
+    def test_empty_list_is_valid_discovery_but_not_profile_acceptance(self):
+        p = self.probe("empty")
+        self.assertEqual(p.returncode, 0, p.stderr)
+        self.assertEqual(p.stdout, "")
+
+    def test_timeout_reaps_descendant(self):
+        p = self.probe("child")
+        self.assertNotEqual(p.returncode, 0)
+        pid = int((self.root / "child-pid").read_text())
+        # Orphan zombies may briefly await init; they must not be executing.
+        state = subprocess.run(["ps", "-o", "stat=", "-p", str(pid)], capture_output=True, text=True)
+        self.assertTrue(state.returncode == 1 or state.stdout.strip().startswith("Z"), state.stdout)
+
+    def test_profile_check_requires_selected_skills_and_preserves_readme(self):
+        from regression import Sandbox, DEMO_SKILL, base_profile
+        box = Sandbox(str(self.root / "repo-test"))
+        spec = {"discovery_cmd": "%s kimi_skills_discovery.py %s" % (sys.executable, self.client),
+                "discovery_format":"commands", "require_profile_skills":True}
+        box.profile(base_profile([DEMO_SKILL], {"kimi":spec,"shared":{"skills_dir":"~/.agents/skills"}}))
+        self.assertEqual(box.run("apply", "--profile", "harness")[0], 0)
+        readme = Path(box.path(".agents", "skills", "README.md"))
+        readme.write_text("upstream index must survive\n")
+        for mode, expected in [("after",0),("empty",1),("new-error",1)]:
+            (self.root / "mode").write_text(mode)
+            code, out = box.run("check", "--profile", "harness")
+            (self.root / (mode+".env-check.txt")).write_text(out)
+            self.assertEqual(code, expected, out)
+            if mode == "empty": self.assertIn("缺少 Profile Skill", out)
+            if mode == "new-error": self.assertIn("原生发现失败", out)
+            if mode == "after": self.assertIn("额外原生命令 skill:README", out)
+            self.assertEqual(readme.read_text(), "upstream index must survive\n")
+
+if __name__ == "__main__":
+    result = unittest.TextTestRunner().run(unittest.defaultTestLoader.loadTestsFromTestCase(KimiDiscoveryTest))
+    if result.wasSuccessful():
+        shutil.rmtree(ARTIFACTS)
+    else:
+        print("First failure evidence retained:", ARTIFACTS)
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/tools/environment/tests/regression.py
+++ b/tools/environment/tests/regression.py
@@ -74,7 +74,7 @@ class Sandbox(object):
         self.repo = os.path.join(root, "repo")
         self.env_dir = os.path.join(self.repo, "tools", "environment")
         os.makedirs(os.path.join(self.env_dir, "profiles"))
-        for name in ("env.py", "skills_discovery.py"):
+        for name in ("env.py", "skills_discovery.py", "kimi_skills_discovery.py"):
             shutil.copy2(os.path.join(ENV_DIR, name), os.path.join(self.env_dir, name))
         skill_dir = os.path.join(self.repo, "skills", "demo-skill")
         os.makedirs(os.path.join(skill_dir, "clients"))
@@ -638,6 +638,10 @@ def main():
     case_update_rollback_keeps_record(os.path.join(root, "c6"))
     case_discovery_errors_and_timeout(os.path.join(root, "c6", "cli"))
     case_profile_selection(os.path.join(root, "c7"))
+    kimi = subprocess.run([sys.executable, os.path.join(HERE, "kimi_discovery.py")],
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+    write(os.path.join(root, "kimi-discovery.log"), kimi.stdout)
+    check("Kimi ACP 隔离协议与 Profile 缺项回归", kimi.returncode == 0, kimi.stdout if kimi.returncode else "")
     print("\n通过 %d 项，失败 %d 项" % (len(PASSES), len(FAILS)))
     if FAILS:
         for name in FAILS:

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -4,6 +4,8 @@ Repeatable multi-step processes and domain workflows.
 
 ## Index
 
+- [单 Issue 轻量试用](single-issue-trial.md) — setup 按需、项目流程实施、证据与 Issue 闭环。
+
 - [Project learning and remote handoff](learning-and-remote-handoff.md) — escaped-bug lessons, consolidation, transfer and result collection.
 
 - [Implement Batch](implement-batch.md) — isolated implementation with batch-level verification.

--- a/workflows/single-issue-trial.md
+++ b/workflows/single-issue-trial.md
@@ -1,0 +1,40 @@
+# 单 Issue 轻量试用
+
+- Domain: coding
+- 用途：安装 Skills 后，用一个小而可独立验收的 Issue 验证实际帮助。
+
+## 选择入口
+
+普通单 Issue 直接沿用目标仓库的实现、测试和评审流程。仅当测试入口缺失或过时时使用 `setup-aiwb` 核实并维护项目测试手册；已有可靠手册就直接复用。不需要额外的 batch、integrator 或确认仪式，外部操作仍遵循用户授权。
+
+当一个 spec 有多个依赖子 Issue、需要隔离并行实施和统一集成时，由用户显式选择 [implement-batch](implement-batch.md)。单 Issue 也可显式选择它，但普通小修复不必承担这套编排。
+
+> 检查当前 Issue 的实际情况；测试方法不清楚时使用 setup-aiwb，只询问缺失项。随后按本仓流程实现和验证，报告测试边界与剩余问题。
+
+## 一次试用怎么完成
+
+1. **选题与重验。** 选有明确验收条件的小 Issue，对照当前代码重验旧描述；依赖已存在就复用，不按过时描述重复安装或改造。
+2. **测试边界。** 由目标仓库维护启动、隔离目标、测试命令和清理方法。分清本地 fixture、真实服务和真机；缺凭据时如实标记，不默认连接生产。
+3. **实施与评审。** 沿用本仓测试方法和要求的独立评审轴；保留最小修改，已有实现先验证。AIWB 不再包一层相同流程。
+4. **保留失败。** 若全量测试失败，先保留第一次命令、候选、环境与输出。单测、基线或降低并发只作诊断；即使通过，也不能覆盖原失败或证明 flaky 已解决。把证据补进已有问题，别自动 retry 到绿或顺手修无关代码。
+5. **交付闭环。** 在用户授权内提交、推送、建 PR、更新 Issue；按项目门禁确认 CI 和合并结果。报告哪些行为实际执行、哪些仍未验收。没有发布权限时交付本地变更和证据，不宣称 PR/Issue 已闭环。
+
+## 已发生的案例（2026-09-12）
+
+[Study Buddy #75](https://github.com/blackfaced/study-buddy/issues/75) 的旧描述认为缺 Playwright；实查已有依赖，最终复用它，修正不可移植的浏览器路径与隐式测试目标。`setup-aiwb` 帮助建立项目测试手册，实现与独立 Standards / Spec 评审仍沿用项目流程。
+
+[PR #237](https://github.com/blackfaced/study-buddy/pull/237) 已合并为 `6b5839efc99142fe15840c8b61cd4ba879326d38`，#75 已关闭。可复核的 [测试手册](https://github.com/blackfaced/study-buddy/blob/6b5839efc99142fe15840c8b61cd4ba879326d38/docs/testing/integration.md) 与 [验收记录](https://github.com/blackfaced/study-buddy/blob/6b5839efc99142fe15840c8b61cd4ba879326d38/docs/testing/issue-75-acceptance.md) 留在项目仓库，AIWB 不复制其部署知识。
+
+该次默认并发套件出现不同失败点；单文件与降低并发诊断通过，首次失败与对照结果补进 [既有 flaky Issue #187](https://github.com/blackfaced/study-buddy/issues/187#issuecomment-5638771601)。CI 通过不代表本地并发不稳定已修复。这次是 setup-aiwb 的实际使用与隔离测试，不是 implement-batch 或 Kimi 执行验收，也没有生产部署或真机/外部模型验收。
+
+## 报告证据层级
+
+| 状态 | 证明什么 | 不能推出什么 |
+| --- | --- | --- |
+| installed | 受管文件已安装 | 客户端能加载 |
+| natively discoverable | 指定客户端原生接口列出 Skill | Skill 能完成任务 |
+| executed | 指定客户端在任务中实际使用 Skill | 任务结果正确 |
+| isolated-tested | 指定候选通过隔离测试 | 真实服务、API 或真机通过 |
+| live-accepted | 指定候选在约定真实环境满足验收 | 其他客户端、环境或后续版本通过 |
+
+每项结论附候选、客户端、环境、命令/观察和证据位置；缺哪个层级就明确写未验证，不必为了填满表而增加测试。


### PR DESCRIPTION
## Changes

A small Issue had no documented route from Skill installation to ordinary project delivery, and the home-Mac check could not detect Kimi losing its installed Skills. This change adds the single-Issue guide and connects bounded, prompt-free Kimi ACP discovery to the home-mac profile. Missing Skills, malformed/incomplete replies and timeouts fail the check; the owned process group is reaped. The upstream README remains an explicitly reported extra command.

The root Apache-2.0 license now covers maintained first-party artifacts, preserving the engineering-principles pack's MIT license and other third-party notices.

Three commits, in requested order:
- #95: lightweight single-Issue trial and source-linked Study Buddy example.
- #94: native Kimi discovery, profile validation and isolated failure/cleanup tests.
- #78: complete official Apache-2.0 text and README scope.

## Validation

- Local environment regression: 85 checks passed, including five Kimi test methods with protocol subcases.
- Local Kimi 0.39.0: seven required first-party Skills discovered; no model prompt sent.
- Changed Markdown local links resolve; git diff --check passes.
- LICENSE matches the Apache official text byte-for-byte; the existing MIT license is unchanged.

The new automated check has **not** been rerun on the home Mac's Kimi 0.41.0. Historical manual discovery is preserved separately. ACP discovery proves command visibility, not Skill execution or source-file uniqueness; the client may write its own session/log metadata.

Closes #95, closes #94, closes #78.
